### PR TITLE
Update webpack 4 and webpack 5 plugins to be compatible with multi-phase Heft

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,4 +79,5 @@ dist
 .vscode
 
 # Heft
+.cache
 .heft

--- a/heft-plugins/heft-webpack4-plugin/.npmignore
+++ b/heft-plugins/heft-webpack4-plugin/.npmignore
@@ -29,3 +29,4 @@
 
 # (Add your project-specific overrides here)
 !/includes/**
+!heft-plugin.json

--- a/heft-plugins/heft-webpack4-plugin/README.md
+++ b/heft-plugins/heft-webpack4-plugin/README.md
@@ -1,11 +1,12 @@
 # @rushstack/heft-webpack4-plugin
 
-This is a Heft plugin for using Webpack 4 during the "bundle" stage.
+This is a Heft plugin for using Webpack 4.
 
 ## Links
 
 - [CHANGELOG.md](
   https://github.com/microsoft/rushstack/blob/main/heft-plugins/heft-webpack4-plugin/CHANGELOG.md) - Find
   out what's new in the latest version
+- [@rushstack/heft](https://www.npmjs.com/package/@rushstack/heft) - Heft is a config-driven toolchain that invokes popular tools such as TypeScript, ESLint, Jest, Webpack, and API Extractor.
 
 Heft is part of the [Rush Stack](https://rushstack.io/) family of projects.

--- a/heft-plugins/heft-webpack4-plugin/heft-plugin.json
+++ b/heft-plugins/heft-webpack4-plugin/heft-plugin.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/heft/heft-plugin.schema.json",
+
+  "lifecyclePlugins": [],
+
+  "taskPlugins": [
+    {
+      "pluginName": "WebpackPlugin",
+      "entryPoint": "./lib/WebpackPlugin"
+    }
+  ]
+}

--- a/heft-plugins/heft-webpack4-plugin/heft-plugin.json
+++ b/heft-plugins/heft-webpack4-plugin/heft-plugin.json
@@ -1,12 +1,11 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/heft/heft-plugin.schema.json",
 
-  "lifecyclePlugins": [],
-
   "taskPlugins": [
     {
-      "pluginName": "WebpackPlugin",
-      "entryPoint": "./lib/WebpackPlugin"
+      "pluginName": "Webpack4Plugin",
+      "entryPoint": "./lib/Webpack4Plugin",
+      "optionsSchema": "./lib/schemas/heft-webpack4-plugin.schema.json"
     }
   ]
 }

--- a/heft-plugins/heft-webpack4-plugin/package.json
+++ b/heft-plugins/heft-webpack4-plugin/package.json
@@ -12,30 +12,26 @@
   "types": "dist/heft-webpack4-plugin.d.ts",
   "license": "MIT",
   "scripts": {
-    "start": "heft test --clean --watch",
     "build": "heft build --clean",
+    "start": "heft test --clean --watch",
     "_phase:build": "heft run --only build -- --clean",
     "_phase:test": "heft run --only test -- --clean"
   },
   "peerDependenciesMeta": {
     "@types/webpack": {
       "optional": true
-    },
-    "@types/webpack-dev-server": {
-      "optional": true
     }
   },
   "peerDependencies": {
     "@rushstack/heft": "^0.45.14",
     "@types/webpack": "^4",
-    "@types/webpack-dev-server": "^3",
     "webpack": "~4.44.2"
   },
   "dependencies": {
     "@rushstack/node-core-library": "workspace:*",
     "@types/tapable": "1.0.6",
     "tapable": "1.1.3",
-    "webpack-dev-server": "~3.11.0"
+    "webpack-dev-server": "~4.9.3"
   },
   "devDependencies": {
     "@rushstack/eslint-config": "workspace:*",
@@ -43,7 +39,6 @@
     "@rushstack/heft": "workspace:*",
     "@types/node": "12.20.24",
     "@types/webpack": "4.41.32",
-    "@types/webpack-dev-server": "3.11.3",
     "webpack": "~4.44.2"
   }
 }

--- a/heft-plugins/heft-webpack4-plugin/package.json
+++ b/heft-plugins/heft-webpack4-plugin/package.json
@@ -12,10 +12,10 @@
   "types": "dist/heft-webpack4-plugin.d.ts",
   "license": "MIT",
   "scripts": {
-    "build": "heft build --clean",
     "start": "heft test --clean --watch",
-    "_phase:build": "heft build --clean",
-    "_phase:test": "heft test --no-build"
+    "build": "heft build --clean",
+    "_phase:build": "heft run --only build -- --clean",
+    "_phase:test": "heft run --only test -- --clean"
   },
   "peerDependenciesMeta": {
     "@types/webpack": {
@@ -33,6 +33,8 @@
   },
   "dependencies": {
     "@rushstack/node-core-library": "workspace:*",
+    "@types/tapable": "1.0.6",
+    "tapable": "1.1.3",
     "webpack-dev-server": "~3.11.0"
   },
   "devDependencies": {
@@ -40,8 +42,8 @@
     "@rushstack/heft-node-rig": "workspace:*",
     "@rushstack/heft": "workspace:*",
     "@types/node": "12.20.24",
-    "@types/webpack-dev-server": "3.11.3",
     "@types/webpack": "4.41.32",
+    "@types/webpack-dev-server": "3.11.3",
     "webpack": "~4.44.2"
   }
 }

--- a/heft-plugins/heft-webpack4-plugin/src/Webpack4Plugin.ts
+++ b/heft-plugins/heft-webpack4-plugin/src/Webpack4Plugin.ts
@@ -159,7 +159,7 @@ export default class Webpack4Plugin implements IHeftTaskPlugin<IWebpack4PluginOp
     const logger: IScopedLogger = taskSession.logger;
 
     if (!webpackConfiguration) {
-      logger.terminal.writeLine('Webpack configuration suppressed, running Webpack skipped');
+      logger.terminal.writeLine('Webpack configuration not provided, running Webpack skipped');
       return;
     }
 

--- a/heft-plugins/heft-webpack4-plugin/src/Webpack4Plugin.ts
+++ b/heft-plugins/heft-webpack4-plugin/src/Webpack4Plugin.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import { AsyncParallelHook, AsyncSeriesWaterfallHook } from 'tapable';
 import type * as TWebpack from 'webpack';
 import type TWebpackDevServer from 'webpack-dev-server';
+import { AsyncParallelHook, AsyncSeriesBailHook, AsyncSeriesHook } from 'tapable';
 import { LegacyAdapters } from '@rushstack/node-core-library';
 import type {
   HeftConfiguration,
@@ -17,7 +17,7 @@ import type {
 import type {
   IWebpackConfiguration,
   IWebpackConfigurationWithDevServer,
-  IWebpack4PluginAccessor,
+  IWebpack4PluginAccessor
 } from './shared';
 import { WebpackConfigurationLoader } from './WebpackConfigurationLoader';
 
@@ -39,13 +39,13 @@ const UNINITIALIZED: 'UNINITIALIZED' = 'UNINITIALIZED';
  */
 export default class Webpack4Plugin implements IHeftTaskPlugin<IWebpack4PluginOptions> {
   private _webpack: typeof TWebpack | undefined;
-  private _webpackConfiguration: IWebpackConfiguration | undefined | typeof UNINITIALIZED
-    = UNINITIALIZED;
+  private _webpackConfiguration: IWebpackConfiguration | undefined | typeof UNINITIALIZED = UNINITIALIZED;
 
   public readonly accessor: IWebpack4PluginAccessor = {
     hooks: {
-      onConfigureWebpack: new AsyncSeriesWaterfallHook(['webpackConfiguration']),
-      onAfterConfigureWebpack: new AsyncParallelHook(['webpackConfiguration']),
+      onLoadConfiguration: new AsyncSeriesBailHook(),
+      onConfigure: new AsyncSeriesHook(['webpackConfiguration']),
+      onAfterConfigure: new AsyncParallelHook(['webpackConfiguration']),
       onEmitStats: new AsyncParallelHook(['webpackStats'])
     }
   };
@@ -60,38 +60,37 @@ export default class Webpack4Plugin implements IHeftTaskPlugin<IWebpack4PluginOp
     let serveMode: boolean;
     let watchMode: boolean;
 
-    // Provide the initial webpack configuration by tapping the hook
-    this.accessor.hooks.onConfigureWebpack.tapPromise(
-      PLUGIN_NAME,
-      async (existingConfiguration: IWebpackConfiguration | undefined | false) => {
-        if (existingConfiguration) {
-          taskSession.logger.terminal.writeVerboseLine(
-            'Skipping loading webpack config file because the webpack config has already been set.'
-          );
-          return existingConfiguration;
-        } else if (existingConfiguration === undefined) {
-          const configurationLoader: WebpackConfigurationLoader = new WebpackConfigurationLoader(
-            taskSession.logger,
-            production,
-            serveMode
-          );
-          const webpack: typeof TWebpack = await this._loadWebpackAsync();
-          return await configurationLoader.tryLoadWebpackConfigurationAsync({
-            ...options,
-            taskSession,
-            heftConfiguration,
-            webpack
-          });
-        }
+    // Provide the initial webpack configuration by tapping the hook. Tap with stage as
+    // MAX_SAFE_INTEGER to ensure that we run last.
+    this.accessor.hooks.onLoadConfiguration.tapPromise(
+      { name: PLUGIN_NAME, stage: Number.MAX_SAFE_INTEGER },
+      async () => {
+        taskSession.logger.terminal.writeVerboseLine('Loading default Webpack configuration');
+        const configurationLoader: WebpackConfigurationLoader = new WebpackConfigurationLoader(
+          taskSession.logger,
+          production,
+          serveMode
+        );
+        const webpack: typeof TWebpack = await this._loadWebpackAsync();
+        return await configurationLoader.tryLoadWebpackConfigurationAsync({
+          ...options,
+          taskSession,
+          heftConfiguration,
+          webpack
+        });
       }
     );
 
     taskSession.hooks.clean.tapPromise(PLUGIN_NAME, async (cleanOptions: IHeftTaskCleanHookOptions) => {
       // Obtain the finalized webpack configuration
-      const webpackConfiguration: IWebpackConfiguration | undefined = await this._getWebpackConfigurationAsync();
+      const webpackConfiguration: IWebpackConfiguration | undefined =
+        await this._getWebpackConfigurationAsync();
       if (webpackConfiguration) {
-        const webpackConfigurationArray: IWebpackConfigurationWithDevServer[] =
-          Array.isArray(webpackConfiguration) ? webpackConfiguration : [webpackConfiguration];
+        const webpackConfigurationArray: IWebpackConfigurationWithDevServer[] = Array.isArray(
+          webpackConfiguration
+        )
+          ? webpackConfiguration
+          : [webpackConfiguration];
 
         // Add each output path to the clean list
         for (const config of webpackConfigurationArray) {
@@ -110,14 +109,9 @@ export default class Webpack4Plugin implements IHeftTaskPlugin<IWebpack4PluginOp
       serveMode = false;
 
       // Run webpack with the finalized webpack configuration
-      const webpackConfiguration: IWebpackConfiguration | undefined = await this._getWebpackConfigurationAsync();
-      await this._runWebpackAsync(
-        taskSession,
-        heftConfiguration,
-        webpackConfiguration,
-        serveMode,
-        watchMode
-      );
+      const webpackConfiguration: IWebpackConfiguration | undefined =
+        await this._getWebpackConfigurationAsync();
+      await this._runWebpackAsync(taskSession, heftConfiguration, webpackConfiguration, serveMode, watchMode);
     });
   }
 
@@ -131,19 +125,25 @@ export default class Webpack4Plugin implements IHeftTaskPlugin<IWebpack4PluginOp
   private async _getWebpackConfigurationAsync(): Promise<IWebpackConfiguration | undefined> {
     if (this._webpackConfiguration === UNINITIALIZED) {
       // Obtain the webpack configuration by calling into the hook. This hook is always used
-      // since the this plugin taps the hook.
-      const webpackConfiguration: IWebpackConfiguration | undefined | false =
-        await this.accessor.hooks.onConfigureWebpack.promise();
+      // since the this plugin taps the hook to provide the default configuration.
+      const webpackConfiguration: IWebpackConfiguration | false =
+        (await this.accessor.hooks.onLoadConfiguration.promise())!;
 
-      if (webpackConfiguration !== false) {
-        this._webpackConfiguration = webpackConfiguration;
-        if (webpackConfiguration && this.accessor.hooks.onAfterConfigureWebpack.isUsed()) {
-          // Provide the finalized configuration
-          await this.accessor.hooks.onAfterConfigureWebpack.promise(webpackConfiguration);
-        }
-      } else {
+      if (webpackConfiguration === false) {
         // It is initialized, but suppressed. Set the configuration to undefined.
         this._webpackConfiguration = undefined;
+      } else {
+        this._webpackConfiguration = webpackConfiguration;
+        if (webpackConfiguration) {
+          if (this.accessor.hooks.onConfigure.isUsed()) {
+            // Allow for plugins to customise the configuration
+            await this.accessor.hooks.onConfigure.promise(webpackConfiguration);
+          }
+          if (this.accessor.hooks.onAfterConfigure.isUsed()) {
+            // Provide the finalized configuration
+            await this.accessor.hooks.onAfterConfigure.promise(webpackConfiguration);
+          }
+        }
       }
     }
     return this._webpackConfiguration;
@@ -156,11 +156,13 @@ export default class Webpack4Plugin implements IHeftTaskPlugin<IWebpack4PluginOp
     serveMode: boolean,
     watchMode: boolean
   ): Promise<void> {
+    const logger: IScopedLogger = taskSession.logger;
+
     if (!webpackConfiguration) {
+      logger.terminal.writeLine('Webpack configuration suppressed, running Webpack skipped');
       return;
     }
 
-    const logger: IScopedLogger = taskSession.logger;
     const webpack: typeof TWebpack = await this._loadWebpackAsync();
     logger.terminal.writeLine(`Using Webpack version ${webpack.version}`);
 

--- a/heft-plugins/heft-webpack4-plugin/src/Webpack4Plugin.ts
+++ b/heft-plugins/heft-webpack4-plugin/src/Webpack4Plugin.ts
@@ -74,8 +74,9 @@ export default class Webpack4Plugin implements IHeftTaskPlugin<IWebpack4PluginOp
           const webpack: typeof TWebpack = await this._getWebpackAsync();
           return await configurationLoader.tryLoadWebpackConfigurationAsync({
             ...options,
-            webpack,
-            buildFolder: heftConfiguration.buildFolder
+            taskSession,
+            heftConfiguration,
+            webpack
           });
         }
       }
@@ -106,7 +107,13 @@ export default class Webpack4Plugin implements IHeftTaskPlugin<IWebpack4PluginOp
 
       // Run webpack with the finalized webpack configuration
       const webpackConfiguration: IWebpackConfiguration | null = await this._getWebpackConfigurationAsync();
-      await this._runWebpackAsync(taskSession, heftConfiguration, webpackConfiguration, serveMode, watchMode);
+      await this._runWebpackAsync(
+        taskSession,
+        heftConfiguration,
+        webpackConfiguration,
+        serveMode,
+        watchMode
+      );
     });
   }
 
@@ -202,28 +209,18 @@ export default class Webpack4Plugin implements IHeftTaskPlugin<IWebpack4PluginOp
       // Register a plugin to callback after webpack is done with the first compilation
       // so we can move on to post-build
       let firstCompilationDoneCallback: (() => void) | undefined;
-      const originalBeforeCallback: typeof options.setupMiddlewares | undefined = options.setupMiddlewares;
-      options.setupMiddlewares = (middlewares, devServer) => {
-        compiler.hooks.done.tap(PLUGIN_NAME, () => {
-          if (firstCompilationDoneCallback) {
-            firstCompilationDoneCallback();
-            firstCompilationDoneCallback = undefined;
-          }
-        });
-
-        if (originalBeforeCallback) {
-          return originalBeforeCallback(middlewares, devServer);
+      compiler.hooks.done.tap(PLUGIN_NAME, () => {
+        if (firstCompilationDoneCallback) {
+          firstCompilationDoneCallback();
+          firstCompilationDoneCallback = undefined;
         }
-        return middlewares;
-      };
+      });
 
       // The webpack-dev-server package has a design flaw, where merely loading its package will set the
       // WEBPACK_DEV_SERVER environment variable -- even if no APIs are accessed. This environment variable
-      // causes incorrect behavior if Heft is not running in serve mode. Thus, we need to be careful to call require()
-      // only if Heft is in serve mode.
+      // causes incorrect behavior if Heft is not running in serve mode. Thus, we need to be careful to call
+      // require() only if Heft is in serve mode.
       const WebpackDevServer: typeof TWebpackDevServer = await import(WEBPACK_DEV_SERVER_PACKAGE_NAME);
-      // TODO: the WebpackDevServer accepts a third parameter for a logger. We should make
-      // use of that to make logging cleaner
       const webpackDevServer: TWebpackDevServer = new WebpackDevServer(options, compiler);
 
       await new Promise<void>((resolve: () => void, reject: (error: Error) => void) => {

--- a/heft-plugins/heft-webpack4-plugin/src/WebpackConfigurationLoader.ts
+++ b/heft-plugins/heft-webpack4-plugin/src/WebpackConfigurationLoader.ts
@@ -6,7 +6,13 @@ import type * as TWebpack from 'webpack';
 import { FileSystem } from '@rushstack/node-core-library';
 import type { IScopedLogger } from '@rushstack/heft';
 
+import type { IWebpack4PluginOptions } from './Webpack4Plugin';
 import type { IWebpackConfiguration } from './shared';
+
+interface ILoadWebpackConfigurationOptions extends IWebpack4PluginOptions {
+  buildFolder: string;
+  webpack: typeof TWebpack;
+}
 
 /**
  * See https://webpack.js.org/api/cli/#environment-options
@@ -14,7 +20,11 @@ import type { IWebpackConfiguration } from './shared';
 interface IWebpackConfigFunctionEnv {
   prod: boolean;
   production: boolean;
+
+  // Non-standard environment options
+  webpack: typeof TWebpack;
 }
+
 type IWebpackConfigJsExport =
   | TWebpack.Configuration
   | TWebpack.Configuration[]
@@ -24,13 +34,13 @@ type IWebpackConfigJsExport =
   | ((env: IWebpackConfigFunctionEnv) => Promise<TWebpack.Configuration | TWebpack.Configuration[]>);
 type IWebpackConfigJs = IWebpackConfigJsExport | { default: IWebpackConfigJsExport };
 
-const WEBPACK_CONFIG_FILENAME: string = 'webpack.config.js';
-const WEBPACK_DEV_CONFIG_FILENAME: string = 'webpack.dev.config.js';
+const DEFAULT_WEBPACK_CONFIG_PATH: './webpack.config.js' = './webpack.config.js';
+const DEFAULT_WEBPACK_DEV_CONFIG_PATH: './webpack.dev.config.js' = './webpack.dev.config.js';
 
 export class WebpackConfigurationLoader {
-  private _logger: IScopedLogger;
-  private _production: boolean;
-  private _serveMode: boolean;
+  private readonly _logger: IScopedLogger;
+  private readonly _production: boolean;
+  private readonly _serveMode: boolean;
 
   public constructor(logger: IScopedLogger, production: boolean, serveMode: boolean) {
     this._logger = logger;
@@ -38,28 +48,32 @@ export class WebpackConfigurationLoader {
     this._serveMode = serveMode;
   }
 
-  public async tryLoadWebpackConfigAsync(buildFolder: string): Promise<IWebpackConfiguration | undefined> {
+  public async tryLoadWebpackConfigurationAsync(
+    options: ILoadWebpackConfigurationOptions
+  ): Promise<IWebpackConfiguration | undefined> {
     // TODO: Eventually replace this custom logic with a call to this utility in in webpack-cli:
     // https://github.com/webpack/webpack-cli/blob/next/packages/webpack-cli/lib/groups/ConfigGroup.js
 
+    const { buildFolder, configurationPath, devConfigurationPath, webpack } = options;
     let webpackConfigJs: IWebpackConfigJs | undefined;
 
     try {
       if (this._serveMode) {
+        const devConfigPath: string =
+          path.resolve(buildFolder, devConfigurationPath || DEFAULT_WEBPACK_DEV_CONFIG_PATH);
         this._logger.terminal.writeVerboseLine(
-          `Attempting to load webpack configuration from "${WEBPACK_DEV_CONFIG_FILENAME}".`
+          `Attempting to load webpack configuration from "${devConfigPath}".`
         );
-        webpackConfigJs = await this._tryLoadWebpackConfigurationAsync(
-          buildFolder,
-          WEBPACK_DEV_CONFIG_FILENAME
-        );
+        webpackConfigJs = await this._tryLoadWebpackConfigurationInnerAsync(devConfigPath);
       }
 
       if (!webpackConfigJs) {
+        const configPath: string =
+          path.resolve(buildFolder, configurationPath || DEFAULT_WEBPACK_CONFIG_PATH);
         this._logger.terminal.writeVerboseLine(
-          `Attempting to load webpack configuration from "${WEBPACK_CONFIG_FILENAME}".`
+          `Attempting to load webpack configuration from "${configPath}".`
         );
-        webpackConfigJs = await this._tryLoadWebpackConfigurationAsync(buildFolder, WEBPACK_CONFIG_FILENAME);
+        webpackConfigJs = await this._tryLoadWebpackConfigurationInnerAsync(configPath);
       }
     } catch (error) {
       this._logger.emitError(error as Error);
@@ -70,7 +84,7 @@ export class WebpackConfigurationLoader {
         (webpackConfigJs as { default: IWebpackConfigJsExport }).default || webpackConfigJs;
 
       if (typeof webpackConfig === 'function') {
-        return webpackConfig({ prod: this._production, production: this._production });
+        return webpackConfig({ prod: this._production, production: this._production, webpack });
       } else {
         return webpackConfig;
       }
@@ -79,17 +93,15 @@ export class WebpackConfigurationLoader {
     }
   }
 
-  private async _tryLoadWebpackConfigurationAsync(
-    buildFolder: string,
-    configurationFilename: string
+  private async _tryLoadWebpackConfigurationInnerAsync(
+    configurationPath: string
   ): Promise<IWebpackConfigJs | undefined> {
-    const fullWebpackConfigPath: string = path.join(buildFolder, configurationFilename);
-    const configExists: boolean = await FileSystem.existsAsync(fullWebpackConfigPath);
+    const configExists: boolean = await FileSystem.existsAsync(configurationPath);
     if (configExists) {
       try {
-        return await import(fullWebpackConfigPath);
+        return await import(configurationPath);
       } catch (e) {
-        throw new Error(`Error loading webpack configuration at "${fullWebpackConfigPath}": ${e}`);
+        throw new Error(`Error loading webpack configuration at "${configurationPath}": ${e}`);
       }
     } else {
       return undefined;

--- a/heft-plugins/heft-webpack4-plugin/src/WebpackConfigurationLoader.ts
+++ b/heft-plugins/heft-webpack4-plugin/src/WebpackConfigurationLoader.ts
@@ -4,13 +4,14 @@
 import * as path from 'path';
 import type * as TWebpack from 'webpack';
 import { FileSystem } from '@rushstack/node-core-library';
-import type { IScopedLogger } from '@rushstack/heft';
+import type { IScopedLogger, IHeftTaskSession, HeftConfiguration } from '@rushstack/heft';
 
 import type { IWebpack4PluginOptions } from './Webpack4Plugin';
 import type { IWebpackConfiguration } from './shared';
 
 interface ILoadWebpackConfigurationOptions extends IWebpack4PluginOptions {
-  buildFolder: string;
+  taskSession: IHeftTaskSession;
+  heftConfiguration: HeftConfiguration;
   webpack: typeof TWebpack;
 }
 
@@ -22,6 +23,8 @@ interface IWebpackConfigFunctionEnv {
   production: boolean;
 
   // Non-standard environment options
+  taskSession: IHeftTaskSession;
+  heftConfiguration: HeftConfiguration;
   webpack: typeof TWebpack;
 }
 
@@ -54,10 +57,17 @@ export class WebpackConfigurationLoader {
     // TODO: Eventually replace this custom logic with a call to this utility in in webpack-cli:
     // https://github.com/webpack/webpack-cli/blob/next/packages/webpack-cli/lib/groups/ConfigGroup.js
 
-    const { buildFolder, configurationPath, devConfigurationPath, webpack } = options;
+    const {
+      taskSession,
+      heftConfiguration,
+      configurationPath,
+      devConfigurationPath,
+      webpack
+    } = options;
     let webpackConfigJs: IWebpackConfigJs | undefined;
 
     try {
+      const buildFolder: string = heftConfiguration.buildFolder;
       if (this._serveMode) {
         const devConfigPath: string =
           path.resolve(buildFolder, devConfigurationPath || DEFAULT_WEBPACK_DEV_CONFIG_PATH);
@@ -84,7 +94,13 @@ export class WebpackConfigurationLoader {
         (webpackConfigJs as { default: IWebpackConfigJsExport }).default || webpackConfigJs;
 
       if (typeof webpackConfig === 'function') {
-        return webpackConfig({ prod: this._production, production: this._production, webpack });
+        return webpackConfig({
+          prod: this._production,
+          production: this._production,
+          taskSession,
+          heftConfiguration,
+          webpack
+        });
       } else {
         return webpackConfig;
       }

--- a/heft-plugins/heft-webpack4-plugin/src/WebpackConfigurationLoader.ts
+++ b/heft-plugins/heft-webpack4-plugin/src/WebpackConfigurationLoader.ts
@@ -21,7 +21,7 @@ type IWebpackConfigJs = IWebpackConfigJsExport | { default: IWebpackConfigJsExpo
 interface ILoadWebpackConfigurationOptions extends IWebpack4PluginOptions {
   taskSession: IHeftTaskSession;
   heftConfiguration: HeftConfiguration;
-  webpack: typeof TWebpack;
+  loadWebpackAsyncFn: () => Promise<typeof TWebpack>;
 }
 
 const DEFAULT_WEBPACK_CONFIG_PATH: './webpack.config.js' = './webpack.config.js';
@@ -44,20 +44,17 @@ export class WebpackConfigurationLoader {
     // TODO: Eventually replace this custom logic with a call to this utility in in webpack-cli:
     // https://github.com/webpack/webpack-cli/blob/next/packages/webpack-cli/lib/groups/ConfigGroup.js
 
-    const {
-      taskSession,
-      heftConfiguration,
-      configurationPath,
-      devConfigurationPath,
-      webpack
-    } = options;
+    const { taskSession, heftConfiguration, configurationPath, devConfigurationPath, loadWebpackAsyncFn } =
+      options;
     let webpackConfigJs: IWebpackConfigJs | undefined;
 
     try {
       const buildFolder: string = heftConfiguration.buildFolder;
       if (this._serveMode) {
-        const devConfigPath: string =
-          path.resolve(buildFolder, devConfigurationPath || DEFAULT_WEBPACK_DEV_CONFIG_PATH);
+        const devConfigPath: string = path.resolve(
+          buildFolder,
+          devConfigurationPath || DEFAULT_WEBPACK_DEV_CONFIG_PATH
+        );
         this._logger.terminal.writeVerboseLine(
           `Attempting to load webpack configuration from "${devConfigPath}".`
         );
@@ -65,8 +62,10 @@ export class WebpackConfigurationLoader {
       }
 
       if (!webpackConfigJs) {
-        const configPath: string =
-          path.resolve(buildFolder, configurationPath || DEFAULT_WEBPACK_CONFIG_PATH);
+        const configPath: string = path.resolve(
+          buildFolder,
+          configurationPath || DEFAULT_WEBPACK_CONFIG_PATH
+        );
         this._logger.terminal.writeVerboseLine(
           `Attempting to load webpack configuration from "${configPath}".`
         );
@@ -81,12 +80,13 @@ export class WebpackConfigurationLoader {
         (webpackConfigJs as { default: IWebpackConfigJsExport }).default || webpackConfigJs;
 
       if (typeof webpackConfig === 'function') {
+        // Defer loading of webpack until we know for sure that we will need it
         return webpackConfig({
           prod: this._production,
           production: this._production,
           taskSession,
           heftConfiguration,
-          webpack
+          webpack: await loadWebpackAsyncFn()
         });
       } else {
         return webpackConfig;

--- a/heft-plugins/heft-webpack4-plugin/src/index.ts
+++ b/heft-plugins/heft-webpack4-plugin/src/index.ts
@@ -1,11 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-export { PLUGIN_NAME as PluginName } from './WebpackPlugin';
+export { PLUGIN_NAME as PluginName } from './Webpack4Plugin';
 
 export type {
   IWebpackConfigurationWithDevServer,
   IWebpackConfiguration,
-  IWebpackPluginAccessor,
-  IWebpackVersions
+  IWebpack4PluginAccessor
 } from './shared';

--- a/heft-plugins/heft-webpack4-plugin/src/index.ts
+++ b/heft-plugins/heft-webpack4-plugin/src/index.ts
@@ -6,5 +6,7 @@ export { PLUGIN_NAME as PluginName } from './Webpack4Plugin';
 export type {
   IWebpackConfigurationWithDevServer,
   IWebpackConfiguration,
-  IWebpack4PluginAccessor
+  IWebpackConfigurationFnEnvironment,
+  IWebpack4PluginAccessor,
+  IWebpack4PluginAccessorHooks
 } from './shared';

--- a/heft-plugins/heft-webpack4-plugin/src/index.ts
+++ b/heft-plugins/heft-webpack4-plugin/src/index.ts
@@ -1,18 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import type { IHeftPlugin } from '@rushstack/heft';
+export { PLUGIN_NAME as PluginName } from './WebpackPlugin';
 
-import { WebpackPlugin } from './WebpackPlugin';
-
-export {
+export type {
   IWebpackConfigurationWithDevServer,
   IWebpackConfiguration,
-  IWebpackBuildStageProperties,
-  IWebpackBundleSubstageProperties
+  IWebpackPluginAccessor,
+  IWebpackVersions
 } from './shared';
-
-/**
- * @internal
- */
-export default new WebpackPlugin() as IHeftPlugin;

--- a/heft-plugins/heft-webpack4-plugin/src/schemas/heft-webpack4-plugin.schema.json
+++ b/heft-plugins/heft-webpack4-plugin/src/schemas/heft-webpack4-plugin.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Webpack 4 Plugin Configuration",
+  "description": "Defines options for Webpack 4 plugin execution.",
+  "type": "object",
+
+  "additionalProperties": false,
+
+  "properties": {
+    "$schema": {
+      "description": "Part of the JSON Schema standard, this optional keyword declares the URL of the schema that the file conforms to. Editors may download the schema and use it to perform syntax highlighting.",
+      "type": "string"
+    },
+
+    "devConfigurationPath": {
+      "description": "Specifies a relative path to the Webpack dev configuration, which is used in \"serve\" mode. The default value is \"./webpack.dev.config.js\".",
+      "type": "string"
+    },
+
+    "configurationPath": {
+      "description": "Specifies a relative path to the Webpack configuration. The default value is \"./webpack.config.js\".",
+      "type": "string"
+    }
+  }
+}

--- a/heft-plugins/heft-webpack4-plugin/src/shared.ts
+++ b/heft-plugins/heft-webpack4-plugin/src/shared.ts
@@ -1,8 +1,19 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import type { Configuration as WebpackDevServerConfiguration } from 'webpack-dev-server';
 import type * as TWebpack from 'webpack';
+// Compensate for webpack-dev-server referencing constructs from webpack 5
+declare module 'webpack' {
+  export type MultiStats = TWebpack.compilation.MultiStats;
+  export type StatsOptions = unknown;
+  export type StatsCompilation = TWebpack.compilation.Compilation;
+
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  export interface Compiler {
+    watching?: unknown;
+  }
+}
+import type { Configuration as WebpackDevServerConfiguration } from 'webpack-dev-server';
 import type { AsyncParallelHook, AsyncSeriesWaterfallHook } from 'tapable';
 
 /**
@@ -23,40 +34,26 @@ export type IWebpackConfiguration =
 /**
  * @public
  */
-export interface IWebpackVersions {
-  webpackVersion: string;
-  webpackDevServerVersion: string;
-}
-
-/**
- * @public
- */
-export interface IWebpackPluginAccessor {
-  /**
-   * A hook that provides the versions of Webpack and Webpack Dev Server.
-   */
-  readonly onEmitWebpackVersionsHook?: AsyncParallelHook<IWebpackVersions>;
+export interface IWebpack4PluginAccessor {
   /**
    * A hook that allows for modification of the  configuration used by the Webpack
-   * plugin. This must be populated for Webpack to run. If webpackConfigFilePath is
-   * specified, this will be populated automatically with the exports of the config
-   * file referenced in that property.
+   * plugin. This must be populated for Webpack to run. If a webpack configuration is
+   * provided, this will be populated automatically with the exports of the config
+   * file.
    *
    * @remarks
-   * Tapable event handlers can return `null` instead of `undefined` to suppress
+   * Tapable event handlers can return `false` instead of `undefined` to suppress
    * other handlers from creating a configuration object.
    */
-  // We are inheriting this problem from Tapable's API
-  // eslint-disable-next-line @rushstack/no-new-null
-  readonly onConfigureWebpackHook?: AsyncSeriesWaterfallHook<IWebpackConfiguration | null>;
+  readonly onConfigureWebpackHook: AsyncSeriesWaterfallHook<IWebpackConfiguration | false>;
   /**
    * A hook that provides the finalized configuration that will be used by Webpack.
+   * If the configuration object is supressed, this hook will not be called.
    */
-  // We are inheriting this problem from Tapable's API
-  // eslint-disable-next-line @rushstack/no-new-null
-  readonly onAfterConfigureWebpackHook?: AsyncParallelHook<IWebpackConfiguration | null>;
+  readonly onAfterConfigureWebpackHook: AsyncParallelHook<IWebpackConfiguration>;
   /**
-   * A hook that provides the stats output from Webpack.
+   * A hook that provides the stats output from Webpack. If the configuration object
+   * is suppressed, this hook will not be called.
    */
-  readonly onEmitStatsHook?: AsyncParallelHook<TWebpack.Stats | TWebpack.compilation.MultiStats>;
+  readonly onEmitStatsHook: AsyncParallelHook<TWebpack.Stats | TWebpack.compilation.MultiStats>;
 }

--- a/heft-plugins/heft-webpack4-plugin/src/shared.ts
+++ b/heft-plugins/heft-webpack4-plugin/src/shared.ts
@@ -2,13 +2,13 @@
 // See LICENSE in the project root for license information.
 
 import type { Configuration as WebpackDevServerConfiguration } from 'webpack-dev-server';
-import type * as webpack from 'webpack';
-import type { IBuildStageProperties, IBundleSubstageProperties } from '@rushstack/heft';
+import type * as TWebpack from 'webpack';
+import type { AsyncParallelHook, AsyncSeriesWaterfallHook } from 'tapable';
 
 /**
  * @public
  */
-export interface IWebpackConfigurationWithDevServer extends webpack.Configuration {
+export interface IWebpackConfigurationWithDevServer extends TWebpack.Configuration {
   devServer?: WebpackDevServerConfiguration;
 }
 
@@ -23,12 +23,24 @@ export type IWebpackConfiguration =
 /**
  * @public
  */
-export interface IWebpackBundleSubstageProperties extends IBundleSubstageProperties {
+export interface IWebpackVersions {
+  webpackVersion: string;
+  webpackDevServerVersion: string;
+}
+
+/**
+ * @public
+ */
+export interface IWebpackPluginAccessor {
   /**
-   * The configuration used by the Webpack plugin. This must be populated
-   * for Webpack to run. If webpackConfigFilePath is specified,
-   * this will be populated automatically with the exports of the
-   * config file referenced in that property.
+   * A hook that provides the versions of Webpack and Webpack Dev Server.
+   */
+  readonly onEmitWebpackVersionsHook?: AsyncParallelHook<IWebpackVersions>;
+  /**
+   * A hook that allows for modification of the  configuration used by the Webpack
+   * plugin. This must be populated for Webpack to run. If webpackConfigFilePath is
+   * specified, this will be populated automatically with the exports of the config
+   * file referenced in that property.
    *
    * @remarks
    * Tapable event handlers can return `null` instead of `undefined` to suppress
@@ -36,12 +48,15 @@ export interface IWebpackBundleSubstageProperties extends IBundleSubstagePropert
    */
   // We are inheriting this problem from Tapable's API
   // eslint-disable-next-line @rushstack/no-new-null
-  webpackConfiguration?: webpack.Configuration | webpack.Configuration[] | null;
-}
-
-/**
- * @public
- */
-export interface IWebpackBuildStageProperties extends IBuildStageProperties {
-  webpackStats?: webpack.Stats | webpack.compilation.MultiStats;
+  readonly onConfigureWebpackHook?: AsyncSeriesWaterfallHook<IWebpackConfiguration | null>;
+  /**
+   * A hook that provides the finalized configuration that will be used by Webpack.
+   */
+  // We are inheriting this problem from Tapable's API
+  // eslint-disable-next-line @rushstack/no-new-null
+  readonly onAfterConfigureWebpackHook?: AsyncParallelHook<IWebpackConfiguration | null>;
+  /**
+   * A hook that provides the stats output from Webpack.
+   */
+  readonly onEmitStatsHook?: AsyncParallelHook<TWebpack.Stats | TWebpack.compilation.MultiStats>;
 }

--- a/heft-plugins/heft-webpack4-plugin/src/shared.ts
+++ b/heft-plugins/heft-webpack4-plugin/src/shared.ts
@@ -15,6 +15,41 @@ declare module 'webpack' {
 }
 import type { Configuration as WebpackDevServerConfiguration } from 'webpack-dev-server';
 import type { AsyncParallelHook, AsyncSeriesWaterfallHook } from 'tapable';
+import type { IHeftTaskSession, HeftConfiguration } from '@rushstack/heft';
+
+/**
+ * The environment passed into the Webpack configuration function. Loosely based
+ * on the default Webpack environment options, specified here:
+ * https://webpack.js.org/api/cli/#environment-options
+ *
+ * @public
+ */
+export interface IWebpackConfigurationFnEnvironment {
+  /**
+   * Whether or not the run is in production mode. Synonym of
+   * IWebpackConfigurationFnEnvironment.production.
+   */
+  prod: boolean;
+  /**
+   * Whether or not the run is in production mode. Synonym of
+   * IWebpackConfigurationFnEnvironment.prod.
+   */
+  production: boolean;
+
+  // Non-standard environment options
+  /**
+   * The task session provided to the plugin.
+   */
+  taskSession: IHeftTaskSession;
+  /**
+   * The Heft configuration provided to the plugin.
+   */
+  heftConfiguration: HeftConfiguration;
+  /**
+   * The resolved Webpack package.
+   */
+  webpack: typeof TWebpack;
+}
 
 /**
  * @public
@@ -28,13 +63,12 @@ export interface IWebpackConfigurationWithDevServer extends TWebpack.Configurati
  */
 export type IWebpackConfiguration =
   | IWebpackConfigurationWithDevServer
-  | IWebpackConfigurationWithDevServer[]
-  | undefined;
+  | IWebpackConfigurationWithDevServer[];
 
 /**
  * @public
  */
-export interface IWebpack4PluginAccessor {
+export interface IWebpack4PluginAccessorHooks {
   /**
    * A hook that allows for modification of the  configuration used by the Webpack
    * plugin. This must be populated for Webpack to run. If a webpack configuration is
@@ -45,15 +79,25 @@ export interface IWebpack4PluginAccessor {
    * Tapable event handlers can return `false` instead of `undefined` to suppress
    * other handlers from creating a configuration object.
    */
-  readonly onConfigureWebpackHook: AsyncSeriesWaterfallHook<IWebpackConfiguration | false>;
+  readonly onConfigureWebpack: AsyncSeriesWaterfallHook<IWebpackConfiguration | undefined | false>;
   /**
    * A hook that provides the finalized configuration that will be used by Webpack.
    * If the configuration object is supressed, this hook will not be called.
    */
-  readonly onAfterConfigureWebpackHook: AsyncParallelHook<IWebpackConfiguration>;
+  readonly onAfterConfigureWebpack: AsyncParallelHook<IWebpackConfiguration>;
   /**
    * A hook that provides the stats output from Webpack. If the configuration object
    * is suppressed, this hook will not be called.
    */
-  readonly onEmitStatsHook: AsyncParallelHook<TWebpack.Stats | TWebpack.compilation.MultiStats>;
+  readonly onEmitStats: AsyncParallelHook<TWebpack.Stats | TWebpack.compilation.MultiStats>;
+}
+
+/**
+ * @public
+ */
+export interface IWebpack4PluginAccessor {
+  /**
+   * Hooks that are called at various points in the Webpack plugin lifecycle.
+   */
+  hooks: IWebpack4PluginAccessorHooks;
 }

--- a/heft-plugins/heft-webpack5-plugin/.npmignore
+++ b/heft-plugins/heft-webpack5-plugin/.npmignore
@@ -29,3 +29,4 @@
 
 # (Add your project-specific overrides here)
 !/includes/**
+!heft-plugin.json

--- a/heft-plugins/heft-webpack5-plugin/README.md
+++ b/heft-plugins/heft-webpack5-plugin/README.md
@@ -1,11 +1,12 @@
 # @rushstack/heft-webpack5-plugin
 
-This is a Heft plugin for using Webpack 5 during the "bundle" stage.
+This is a Heft plugin for using Webpack 5.
 
 ## Links
 
 - [CHANGELOG.md](
   https://github.com/microsoft/rushstack/blob/main/heft-plugins/heft-webpack5-plugin/CHANGELOG.md) - Find
   out what's new in the latest version
+- [@rushstack/heft](https://www.npmjs.com/package/@rushstack/heft) - Heft is a config-driven toolchain that invokes popular tools such as TypeScript, ESLint, Jest, Webpack, and API Extractor.
 
 Heft is part of the [Rush Stack](https://rushstack.io/) family of projects.

--- a/heft-plugins/heft-webpack5-plugin/heft-plugin.json
+++ b/heft-plugins/heft-webpack5-plugin/heft-plugin.json
@@ -1,12 +1,11 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/heft/heft-plugin.schema.json",
 
-  "lifecyclePlugins": [],
-
   "taskPlugins": [
     {
-      "pluginName": "WebpackPlugin",
-      "entryPoint": "./lib/WebpackPlugin"
+      "pluginName": "Webpack5Plugin",
+      "entryPoint": "./lib/Webpack5Plugin",
+      "optionsSchema": "./lib/schemas/heft-webpack5-plugin.schema.json"
     }
   ]
 }

--- a/heft-plugins/heft-webpack5-plugin/heft-plugin.json
+++ b/heft-plugins/heft-webpack5-plugin/heft-plugin.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/heft/heft-plugin.schema.json",
+
+  "lifecyclePlugins": [],
+
+  "taskPlugins": [
+    {
+      "pluginName": "WebpackPlugin",
+      "entryPoint": "./lib/WebpackPlugin"
+    }
+  ]
+}

--- a/heft-plugins/heft-webpack5-plugin/package.json
+++ b/heft-plugins/heft-webpack5-plugin/package.json
@@ -12,8 +12,8 @@
   "types": "dist/heft-webpack5-plugin.d.ts",
   "license": "MIT",
   "scripts": {
-    "start": "heft test --clean --watch",
     "build": "heft build --clean",
+    "start": "heft test --clean --watch",
     "_phase:build": "heft run --only build -- --clean",
     "_phase:test": "heft run --only test -- --clean"
   },
@@ -25,7 +25,7 @@
     "@rushstack/node-core-library": "workspace:*",
     "@types/tapable": "1.0.6",
     "tapable": "1.1.3",
-    "webpack-dev-server": "~4.7.4"
+    "webpack-dev-server": "~4.9.3"
   },
   "devDependencies": {
     "@rushstack/eslint-config": "workspace:*",

--- a/heft-plugins/heft-webpack5-plugin/package.json
+++ b/heft-plugins/heft-webpack5-plugin/package.json
@@ -12,10 +12,10 @@
   "types": "dist/heft-webpack5-plugin.d.ts",
   "license": "MIT",
   "scripts": {
-    "build": "heft build --clean",
     "start": "heft test --clean --watch",
-    "_phase:build": "heft build --clean",
-    "_phase:test": "heft test --no-build"
+    "build": "heft build --clean",
+    "_phase:build": "heft run --only build -- --clean",
+    "_phase:test": "heft run --only test -- --clean"
   },
   "peerDependencies": {
     "@rushstack/heft": "^0.45.14",
@@ -23,6 +23,8 @@
   },
   "dependencies": {
     "@rushstack/node-core-library": "workspace:*",
+    "@types/tapable": "1.0.6",
+    "tapable": "1.1.3",
     "webpack-dev-server": "~4.7.4"
   },
   "devDependencies": {

--- a/heft-plugins/heft-webpack5-plugin/src/Webpack5Plugin.ts
+++ b/heft-plugins/heft-webpack5-plugin/src/Webpack5Plugin.ts
@@ -60,31 +60,29 @@ export default class Webpack5Plugin implements IHeftTaskPlugin<IWebpack5PluginOp
     let serveMode: boolean;
     let watchMode: boolean;
 
-    // Provide the initial webpack configuration by tapping the hook. Tap with stage as
-    // MAX_SAFE_INTEGER to ensure that we run last.
-    this.accessor.hooks.onLoadConfiguration.tapPromise(
-      { name: PLUGIN_NAME, stage: Number.MAX_SAFE_INTEGER },
-      async () => {
-        taskSession.logger.terminal.writeVerboseLine('Loading default Webpack configuration');
-        const configurationLoader: WebpackConfigurationLoader = new WebpackConfigurationLoader(
-          taskSession.logger,
-          production,
-          serveMode
-        );
-        const webpack: typeof TWebpack = await this._loadWebpackAsync();
-        return await configurationLoader.tryLoadWebpackConfigurationAsync({
-          ...options,
-          taskSession,
-          heftConfiguration,
-          webpack
-        });
-      }
-    );
+    // TODO: Move this into _getWebpackConfigurationAsync once default parameters are moved
+    const getDefaultWebpackConfigurationFn: () => Promise<IWebpackConfiguration | undefined> = async () => {
+      taskSession.logger.terminal.writeVerboseLine('Loading default Webpack configuration');
+      const configurationLoader: WebpackConfigurationLoader = new WebpackConfigurationLoader(
+        taskSession.logger,
+        production,
+        serveMode
+      );
+      return await configurationLoader.tryLoadWebpackConfigurationAsync({
+        ...options,
+        taskSession,
+        heftConfiguration,
+        loadWebpackAsyncFn: this._loadWebpackAsync.bind(this)
+      });
+    };
 
     taskSession.hooks.clean.tapPromise(PLUGIN_NAME, async (cleanOptions: IHeftTaskCleanHookOptions) => {
+      // TODO: Improve how default parameters are surfaced, since this is a bit of a hack.
+      production = cleanOptions.production;
+
       // Obtain the finalized webpack configuration
       const webpackConfiguration: IWebpackConfiguration | undefined =
-        await this._getWebpackConfigurationAsync();
+        await this._getWebpackConfigurationAsync(getDefaultWebpackConfigurationFn);
       if (webpackConfiguration) {
         const webpackConfigurationArray: IWebpackConfigurationWithDevServer[] = Array.isArray(
           webpackConfiguration
@@ -93,6 +91,8 @@ export default class Webpack5Plugin implements IHeftTaskPlugin<IWebpack5PluginOp
           : [webpackConfiguration];
 
         // Add each output path to the clean list
+        // NOTE: Webpack plugins that write assets to paths that start with '../' or outside of the
+        // `output.path` will need to be manually added to the phase-level cleanup list in heft.json.
         for (const config of webpackConfigurationArray) {
           if (config.output?.path) {
             cleanOptions.addDeleteOperations({ sourcePath: config.output.path });
@@ -110,7 +110,7 @@ export default class Webpack5Plugin implements IHeftTaskPlugin<IWebpack5PluginOp
 
       // Run webpack with the finalized webpack configuration
       const webpackConfiguration: IWebpackConfiguration | undefined =
-        await this._getWebpackConfigurationAsync();
+        await this._getWebpackConfigurationAsync(getDefaultWebpackConfigurationFn);
       await this._runWebpackAsync(taskSession, heftConfiguration, webpackConfiguration, serveMode, watchMode);
     });
   }
@@ -122,28 +122,28 @@ export default class Webpack5Plugin implements IHeftTaskPlugin<IWebpack5PluginOp
     return this._webpack;
   }
 
-  private async _getWebpackConfigurationAsync(): Promise<IWebpackConfiguration | undefined> {
+  private async _getWebpackConfigurationAsync(
+    getDefaultWebpackConfigurationFn: () => Promise<IWebpackConfiguration | undefined>
+  ): Promise<IWebpackConfiguration | undefined> {
     if (this._webpackConfiguration === UNINITIALIZED) {
-      // Obtain the webpack configuration by calling into the hook. This hook is always used
-      // since the this plugin taps the hook to provide the default configuration.
-      const webpackConfiguration: IWebpackConfiguration | false =
-        (await this.accessor.hooks.onLoadConfiguration.promise())!;
+      // Obtain the webpack configuration by calling into the hook. If undefined
+      // is returned, load the default Webpack configuration.
+      const webpackConfiguration: IWebpackConfiguration | false | undefined =
+        (await this.accessor.hooks.onLoadConfiguration.promise()) ??
+        (await getDefaultWebpackConfigurationFn());
 
-      if (webpackConfiguration === false) {
-        // It is initialized, but suppressed. Set the configuration to undefined.
+      if (!webpackConfiguration) {
         this._webpackConfiguration = undefined;
       } else {
-        this._webpackConfiguration = webpackConfiguration;
-        if (webpackConfiguration) {
-          if (this.accessor.hooks.onConfigure.isUsed()) {
-            // Allow for plugins to customise the configuration
-            await this.accessor.hooks.onConfigure.promise(webpackConfiguration);
-          }
-          if (this.accessor.hooks.onAfterConfigure.isUsed()) {
-            // Provide the finalized configuration
-            await this.accessor.hooks.onAfterConfigure.promise(webpackConfiguration);
-          }
+        if (this.accessor.hooks.onConfigure.isUsed()) {
+          // Allow for plugins to customise the configuration
+          await this.accessor.hooks.onConfigure.promise(webpackConfiguration);
         }
+        if (this.accessor.hooks.onAfterConfigure.isUsed()) {
+          // Provide the finalized configuration
+          await this.accessor.hooks.onAfterConfigure.promise(webpackConfiguration);
+        }
+        this._webpackConfiguration = webpackConfiguration;
       }
     }
     return this._webpackConfiguration;

--- a/heft-plugins/heft-webpack5-plugin/src/Webpack5Plugin.ts
+++ b/heft-plugins/heft-webpack5-plugin/src/Webpack5Plugin.ts
@@ -159,7 +159,7 @@ export default class Webpack5Plugin implements IHeftTaskPlugin<IWebpack5PluginOp
     const logger: IScopedLogger = taskSession.logger;
 
     if (!webpackConfiguration) {
-      logger.terminal.writeLine('Webpack configuration suppressed, running Webpack skipped');
+      logger.terminal.writeLine('Webpack configuration not provided, running Webpack skipped');
       return;
     }
 

--- a/heft-plugins/heft-webpack5-plugin/src/Webpack5Plugin.ts
+++ b/heft-plugins/heft-webpack5-plugin/src/Webpack5Plugin.ts
@@ -32,18 +32,22 @@ export interface IWebpack5PluginOptions {
 export const PLUGIN_NAME: 'Webpack5Plugin' = 'Webpack5Plugin';
 const WEBPACK_DEV_SERVER_PACKAGE_NAME: 'webpack-dev-server' = 'webpack-dev-server';
 const WEBPACK_DEV_SERVER_ENV_VAR_NAME: 'WEBPACK_DEV_SERVER' = 'WEBPACK_DEV_SERVER';
+const UNINITIALIZED: 'UNINITIALIZED' = 'UNINITIALIZED';
 
 /**
  * @internal
  */
 export default class Webpack5Plugin implements IHeftTaskPlugin<IWebpack5PluginOptions> {
   private _webpack: typeof TWebpack | undefined;
-  private _webpackConfiguration: IWebpackConfiguration | undefined;
+  private _webpackConfiguration: IWebpackConfiguration | undefined | typeof UNINITIALIZED
+    = UNINITIALIZED;
 
   public readonly accessor: IWebpack5PluginAccessor = {
-    onConfigureWebpackHook: new AsyncSeriesWaterfallHook(['webpackConfiguration']),
-    onAfterConfigureWebpackHook: new AsyncParallelHook(['webpackConfiguration']),
-    onEmitStatsHook: new AsyncParallelHook(['webpackStats'])
+    hooks: {
+      onConfigureWebpack: new AsyncSeriesWaterfallHook(['webpackConfiguration']),
+      onAfterConfigureWebpack: new AsyncParallelHook(['webpackConfiguration']),
+      onEmitStats: new AsyncParallelHook(['webpackStats'])
+    }
   };
 
   public apply(
@@ -57,21 +61,21 @@ export default class Webpack5Plugin implements IHeftTaskPlugin<IWebpack5PluginOp
     let watchMode: boolean;
 
     // Provide the initial webpack configuration by tapping the hook
-    this.accessor.onConfigureWebpackHook.tapPromise(
+    this.accessor.hooks.onConfigureWebpack.tapPromise(
       PLUGIN_NAME,
-      async (existingConfiguration: IWebpackConfiguration | false) => {
+      async (existingConfiguration: IWebpackConfiguration | undefined | false) => {
         if (existingConfiguration) {
           taskSession.logger.terminal.writeVerboseLine(
             'Skipping loading webpack config file because the webpack config has already been set.'
           );
           return existingConfiguration;
-        } else {
+        } else if (existingConfiguration === undefined) {
           const configurationLoader: WebpackConfigurationLoader = new WebpackConfigurationLoader(
             taskSession.logger,
             production,
             serveMode
           );
-          const webpack: typeof TWebpack = await this._getWebpackAsync();
+          const webpack: typeof TWebpack = await this._loadWebpackAsync();
           return await configurationLoader.tryLoadWebpackConfigurationAsync({
             ...options,
             taskSession,
@@ -84,7 +88,7 @@ export default class Webpack5Plugin implements IHeftTaskPlugin<IWebpack5PluginOp
 
     taskSession.hooks.clean.tapPromise(PLUGIN_NAME, async (cleanOptions: IHeftTaskCleanHookOptions) => {
       // Obtain the finalized webpack configuration
-      const webpackConfiguration: IWebpackConfiguration | null = await this._getWebpackConfigurationAsync();
+      const webpackConfiguration: IWebpackConfiguration | undefined = await this._getWebpackConfigurationAsync();
       if (webpackConfiguration) {
         const webpackConfigurationArray: IWebpackConfigurationWithDevServer[] =
           Array.isArray(webpackConfiguration) ? webpackConfiguration : [webpackConfiguration];
@@ -106,7 +110,7 @@ export default class Webpack5Plugin implements IHeftTaskPlugin<IWebpack5PluginOp
       serveMode = false;
 
       // Run webpack with the finalized webpack configuration
-      const webpackConfiguration: IWebpackConfiguration | null = await this._getWebpackConfigurationAsync();
+      const webpackConfiguration: IWebpackConfiguration | undefined = await this._getWebpackConfigurationAsync();
       await this._runWebpackAsync(
         taskSession,
         heftConfiguration,
@@ -117,26 +121,29 @@ export default class Webpack5Plugin implements IHeftTaskPlugin<IWebpack5PluginOp
     });
   }
 
-  private async _getWebpackAsync(): Promise<typeof TWebpack> {
+  private async _loadWebpackAsync(): Promise<typeof TWebpack> {
     if (!this._webpack) {
       this._webpack = await import('webpack');
     }
     return this._webpack;
   }
 
-  private async _getWebpackConfigurationAsync(): Promise<IWebpackConfiguration | null> {
-    if (this._webpackConfiguration === undefined) {
+  private async _getWebpackConfigurationAsync(): Promise<IWebpackConfiguration | undefined> {
+    if (this._webpackConfiguration === UNINITIALIZED) {
       // Obtain the webpack configuration by calling into the hook. This hook is always used
       // since the this plugin taps the hook.
-      const webpackConfiguration: IWebpackConfiguration | false =
-        await this.accessor.onConfigureWebpackHook.promise(undefined);
+      const webpackConfiguration: IWebpackConfiguration | undefined | false =
+        await this.accessor.hooks.onConfigureWebpack.promise();
 
       if (webpackConfiguration !== false) {
         this._webpackConfiguration = webpackConfiguration;
-        if (this.accessor.onAfterConfigureWebpackHook.isUsed()) {
+        if (webpackConfiguration && this.accessor.hooks.onAfterConfigureWebpack.isUsed()) {
           // Provide the finalized configuration
-          await this.accessor.onAfterConfigureWebpackHook.promise(webpackConfiguration);
+          await this.accessor.hooks.onAfterConfigureWebpack.promise(webpackConfiguration);
         }
+      } else {
+        // It is initialized, but suppressed. Set the configuration to undefined.
+        this._webpackConfiguration = undefined;
       }
     }
     return this._webpackConfiguration;
@@ -145,7 +152,7 @@ export default class Webpack5Plugin implements IHeftTaskPlugin<IWebpack5PluginOp
   private async _runWebpackAsync(
     taskSession: IHeftTaskSession,
     heftConfiguration: HeftConfiguration,
-    webpackConfiguration: IWebpackConfiguration | null,
+    webpackConfiguration: IWebpackConfiguration | undefined,
     serveMode: boolean,
     watchMode: boolean
   ): Promise<void> {
@@ -154,7 +161,7 @@ export default class Webpack5Plugin implements IHeftTaskPlugin<IWebpack5PluginOp
     }
 
     const logger: IScopedLogger = taskSession.logger;
-    const webpack: typeof TWebpack = await this._getWebpackAsync();
+    const webpack: typeof TWebpack = await this._loadWebpackAsync();
     logger.terminal.writeLine(`Using Webpack version ${webpack.version}`);
 
     let compiler: TWebpack.Compiler | TWebpack.MultiCompiler;
@@ -261,8 +268,8 @@ export default class Webpack5Plugin implements IHeftTaskPlugin<IWebpack5PluginOp
 
       if (stats) {
         this._emitErrors(logger, stats, heftConfiguration.buildFolder);
-        if (this.accessor.onEmitStatsHook.isUsed()) {
-          await this.accessor.onEmitStatsHook.promise(stats);
+        if (this.accessor.hooks.onEmitStats.isUsed()) {
+          await this.accessor.hooks.onEmitStats.promise(stats);
         }
       }
     }

--- a/heft-plugins/heft-webpack5-plugin/src/WebpackConfigurationLoader.ts
+++ b/heft-plugins/heft-webpack5-plugin/src/WebpackConfigurationLoader.ts
@@ -7,35 +7,22 @@ import { FileSystem } from '@rushstack/node-core-library';
 import type { IScopedLogger, IHeftTaskSession, HeftConfiguration } from '@rushstack/heft';
 
 import type { IWebpack5PluginOptions } from './Webpack5Plugin';
-import type { IWebpackConfiguration } from './shared';
-
-interface ILoadWebpackConfigurationOptions extends IWebpack5PluginOptions {
-  taskSession: IHeftTaskSession;
-  heftConfiguration: HeftConfiguration;
-  webpack: typeof TWebpack;
-}
-
-/**
- * See https://webpack.js.org/api/cli/#environment-options
- */
-interface IWebpackConfigFunctionEnv {
-  prod: boolean;
-  production: boolean;
-
-  // Non-standard environment options
-  taskSession: IHeftTaskSession;
-  heftConfiguration: HeftConfiguration;
-  webpack: typeof TWebpack;
-}
+import type { IWebpackConfiguration, IWebpackConfigurationFnEnvironment } from './shared';
 
 type IWebpackConfigJsExport =
   | TWebpack.Configuration
   | TWebpack.Configuration[]
   | Promise<TWebpack.Configuration>
   | Promise<TWebpack.Configuration[]>
-  | ((env: IWebpackConfigFunctionEnv) => TWebpack.Configuration | TWebpack.Configuration[])
-  | ((env: IWebpackConfigFunctionEnv) => Promise<TWebpack.Configuration | TWebpack.Configuration[]>);
+  | ((env: IWebpackConfigurationFnEnvironment) => TWebpack.Configuration | TWebpack.Configuration[])
+  | ((env: IWebpackConfigurationFnEnvironment) => Promise<TWebpack.Configuration | TWebpack.Configuration[]>);
 type IWebpackConfigJs = IWebpackConfigJsExport | { default: IWebpackConfigJsExport };
+
+interface ILoadWebpackConfigurationOptions extends IWebpack5PluginOptions {
+  taskSession: IHeftTaskSession;
+  heftConfiguration: HeftConfiguration;
+  webpack: typeof TWebpack;
+}
 
 const DEFAULT_WEBPACK_CONFIG_PATH: './webpack.config.js' = './webpack.config.js';
 const DEFAULT_WEBPACK_DEV_CONFIG_PATH: './webpack.dev.config.js' = './webpack.dev.config.js';
@@ -117,6 +104,11 @@ export class WebpackConfigurationLoader {
       try {
         return await import(configurationPath);
       } catch (e) {
+        const error: NodeJS.ErrnoException = e as NodeJS.ErrnoException;
+        if (error.code === 'ERR_MODULE_NOT_FOUND') {
+          // No configuration found, return undefined.
+          return undefined;
+        }
         throw new Error(`Error loading webpack configuration at "${configurationPath}": ${e}`);
       }
     } else {

--- a/heft-plugins/heft-webpack5-plugin/src/WebpackPlugin.ts
+++ b/heft-plugins/heft-webpack5-plugin/src/WebpackPlugin.ts
@@ -1,53 +1,123 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import * as nodePath from 'path';
-import type {
-  Compiler as WebpackCompiler,
-  MultiCompiler as WebpackMultiCompiler,
-  Stats as WebpackStats,
-  MultiStats as WebpackMultiStats,
-  StatsCompilation as WebpackStatsCompilation,
-  StatsError as WebpackStatsError
-} from 'webpack';
+import { AsyncParallelHook, AsyncSeriesWaterfallHook } from 'tapable';
+import type * as TWebpack from 'webpack';
 import type TWebpackDevServer from 'webpack-dev-server';
-import { LegacyAdapters, Path, Import, IPackageJson, PackageJsonLookup } from '@rushstack/node-core-library';
+import {
+  FileError,
+  Import,
+  IPackageJson,
+  LegacyAdapters,
+  PackageJsonLookup
+} from '@rushstack/node-core-library';
 import type {
   HeftConfiguration,
-  HeftSession,
-  IBuildStageContext,
-  IBuildStageProperties,
-  IBundleSubstage,
-  IHeftPlugin,
-  ScopedLogger
+  IHeftTaskSession,
+  IHeftTaskCleanHookOptions,
+  IHeftTaskPlugin,
+  IHeftTaskRunHookOptions,
+  IScopedLogger
 } from '@rushstack/heft';
+
 import type {
   IWebpackConfiguration,
-  IWebpackBundleSubstageProperties,
-  IWebpackBuildStageProperties
+  IWebpackConfigurationWithDevServer,
+  IWebpackPluginAccessor,
+  IWebpackVersions
 } from './shared';
 import { WebpackConfigurationLoader } from './WebpackConfigurationLoader';
 
-const webpack: typeof import('webpack') = Import.lazy('webpack', require);
-
-const PLUGIN_NAME: string = 'WebpackPlugin';
+/**
+ * @public
+ */
+export const PLUGIN_NAME: string = 'WebpackPlugin';
 const WEBPACK_DEV_SERVER_PACKAGE_NAME: string = 'webpack-dev-server';
 const WEBPACK_DEV_SERVER_ENV_VAR_NAME: string = 'WEBPACK_DEV_SERVER';
-
-interface IWebpackVersions {
-  webpackVersion: string;
-  webpackDevServerVersion: string;
-}
 
 /**
  * @internal
  */
-export class WebpackPlugin implements IHeftPlugin {
-  public readonly pluginName: string = PLUGIN_NAME;
+export default class WebpackPlugin implements IHeftTaskPlugin {
+  private _webpack: typeof TWebpack | undefined;
+  private _webpackVersions: IWebpackVersions | undefined;
+  private _loadedWebpackConfiguration: IWebpackConfiguration | null | undefined;
 
-  private static _webpackVersions: IWebpackVersions | undefined;
-  private static _getWebpackVersions(): IWebpackVersions {
-    if (!WebpackPlugin._webpackVersions) {
+  public readonly accessor: IWebpackPluginAccessor = {
+    onEmitWebpackVersionsHook: new AsyncParallelHook(['webpackVersions']),
+    onConfigureWebpackHook: new AsyncSeriesWaterfallHook(['webpackConfiguration']),
+    onAfterConfigureWebpackHook: new AsyncParallelHook(['webpackConfiguration']),
+    onEmitStatsHook: new AsyncParallelHook(['webpackStats'])
+  };
+
+  public apply(taskSession: IHeftTaskSession, heftConfiguration: HeftConfiguration): void {
+    // These get set in the run hook and used in the onConfigureWebpackHook
+    let production: boolean;
+    let serveMode: boolean;
+    let watchMode: boolean;
+
+    this.accessor.onConfigureWebpackHook!.tapPromise(
+      PLUGIN_NAME,
+      async (existingConfiguration: IWebpackConfiguration | null) => {
+        if (existingConfiguration) {
+          taskSession.logger.terminal.writeVerboseLine(
+            'Skipping loading webpack config file because the webpack config has already been set.'
+          );
+          return existingConfiguration;
+        } else {
+          const configurationLoader: WebpackConfigurationLoader = new WebpackConfigurationLoader(
+            taskSession.logger,
+            production,
+            serveMode
+          );
+          return await configurationLoader.tryLoadWebpackConfigAsync(heftConfiguration.buildFolder);
+        }
+      }
+    );
+
+    taskSession.hooks.clean.tapPromise(PLUGIN_NAME, async (cleanOptions: IHeftTaskCleanHookOptions) => {
+      // Obtain the finalized webpack configuration
+      const webpackConfiguration: IWebpackConfiguration | null = await this._getWebpackConfigurationAsync();
+      if (webpackConfiguration) {
+        const webpackConfigurationArray: IWebpackConfigurationWithDevServer[] = Array.isArray(
+          webpackConfiguration
+        )
+          ? webpackConfiguration
+          : [webpackConfiguration];
+
+        // Add each output path to the clean list
+        for (const config of webpackConfigurationArray) {
+          if (config.output?.path) {
+            cleanOptions.addDeleteOperations({
+              sourceFolder: config.output.path
+            });
+          }
+        }
+      }
+    });
+
+    taskSession.hooks.run.tapPromise(PLUGIN_NAME, async (runOptions: IHeftTaskRunHookOptions) => {
+      production = runOptions.production;
+      // TODO: Support watch mode
+      watchMode = false;
+      // TODO: Support serve mode
+      serveMode = false;
+
+      // Run webpack with the finalized webpack configuration
+      const webpackConfiguration: IWebpackConfiguration | null = await this._getWebpackConfigurationAsync();
+      await this._runWebpackAsync(taskSession, heftConfiguration, webpackConfiguration, serveMode, watchMode);
+    });
+  }
+
+  private async _getWebpackAsync(): Promise<typeof TWebpack> {
+    if (!this._webpack) {
+      this._webpack = await import('webpack');
+    }
+    return this._webpack;
+  }
+
+  private async _getWebpackVersionsAsync(): Promise<IWebpackVersions> {
+    if (!this._webpackVersions) {
       const webpackDevServerPackageJsonPath: string = Import.resolveModule({
         modulePath: 'webpack-dev-server/package.json',
         baseFolderPath: __dirname
@@ -55,108 +125,68 @@ export class WebpackPlugin implements IHeftPlugin {
       const webpackDevServerPackageJson: IPackageJson = PackageJsonLookup.instance.loadPackageJson(
         webpackDevServerPackageJsonPath
       );
-      WebpackPlugin._webpackVersions = {
+      const webpack: typeof TWebpack = await this._getWebpackAsync();
+      this._webpackVersions = {
         webpackVersion: webpack.version!,
         webpackDevServerVersion: webpackDevServerPackageJson.version
       };
     }
 
-    return WebpackPlugin._webpackVersions;
+    return this._webpackVersions;
   }
 
-  public apply(heftSession: HeftSession, heftConfiguration: HeftConfiguration): void {
-    heftSession.hooks.build.tap(PLUGIN_NAME, (build: IBuildStageContext) => {
-      build.hooks.bundle.tap(PLUGIN_NAME, (bundle: IBundleSubstage) => {
-        bundle.hooks.configureWebpack.tap(
-          { name: PLUGIN_NAME, stage: Number.MIN_SAFE_INTEGER },
-          (webpackConfiguration: unknown) => {
-            const webpackVersions: IWebpackVersions = WebpackPlugin._getWebpackVersions();
-            bundle.properties.webpackVersion = webpack.version;
-            bundle.properties.webpackDevServerVersion = webpackVersions.webpackDevServerVersion;
+  private async _getWebpackConfigurationAsync(): Promise<IWebpackConfiguration | null> {
+    if (this._webpackVersions === undefined || this._loadedWebpackConfiguration === undefined) {
+      // First, load and emit the webpack versions so that plugins can use them when loading
+      // their webpack configuration
+      if (this.accessor.onEmitWebpackVersionsHook!.isUsed()) {
+        this._webpackVersions = await this._getWebpackVersionsAsync();
+        await this.accessor.onEmitWebpackVersionsHook!.promise(this._webpackVersions);
+      }
 
-            return webpackConfiguration;
-          }
-        );
+      // Obtain the webpack configuration by calling into the hook. This hook is always used
+      // since the WebpackPlugin itself taps the hook.
+      const webpackConfiguration: IWebpackConfiguration | null =
+        await this.accessor.onConfigureWebpackHook!.promise(undefined);
 
-        bundle.hooks.configureWebpack.tapPromise(PLUGIN_NAME, async (existingConfiguration: unknown) => {
-          const logger: ScopedLogger = heftSession.requestScopedLogger('configure-webpack');
-          if (existingConfiguration) {
-            logger.terminal.writeVerboseLine(
-              'Skipping loading webpack config file because the webpack config has already been set.'
-            );
-            return existingConfiguration;
-          } else {
-            return await WebpackConfigurationLoader.tryLoadWebpackConfigAsync(
-              logger,
-              heftConfiguration.buildFolder,
-              build.properties
-            );
-          }
-        });
+      // Provide the finalized configuration
+      if (this.accessor.onAfterConfigureWebpackHook!.isUsed()) {
+        await this.accessor.onAfterConfigureWebpackHook!.promise(webpackConfiguration);
+      }
 
-        bundle.hooks.run.tapPromise(PLUGIN_NAME, async () => {
-          await this._runWebpackAsync(
-            heftSession,
-            heftConfiguration,
-            bundle.properties as IWebpackBundleSubstageProperties,
-            build.properties,
-            heftConfiguration.terminalProvider.supportsColor
-          );
-        });
-      });
-    });
+      this._loadedWebpackConfiguration = webpackConfiguration;
+    }
+    return this._loadedWebpackConfiguration;
   }
 
   private async _runWebpackAsync(
-    heftSession: HeftSession,
+    taskSession: IHeftTaskSession,
     heftConfiguration: HeftConfiguration,
-    bundleSubstageProperties: IWebpackBundleSubstageProperties,
-    buildProperties: IBuildStageProperties,
-    supportsColor: boolean
+    webpackConfiguration: IWebpackConfiguration | null,
+    serveMode: boolean,
+    watchMode: boolean
   ): Promise<void> {
-    const webpackConfiguration: IWebpackConfiguration | undefined | null =
-      bundleSubstageProperties.webpackConfiguration;
     if (!webpackConfiguration) {
       return;
     }
 
-    const logger: ScopedLogger = heftSession.requestScopedLogger('webpack');
-    const webpackVersions: IWebpackVersions = WebpackPlugin._getWebpackVersions();
-    if (bundleSubstageProperties.webpackVersion !== webpackVersions.webpackVersion) {
-      logger.emitError(
-        new Error(
-          `The Webpack plugin expected to be configured with Webpack version ${webpackVersions.webpackVersion}, ` +
-            `but the configuration specifies version ${bundleSubstageProperties.webpackVersion}. ` +
-            'Are multiple versions of the Webpack plugin present?'
-        )
-      );
-    }
-
-    if (bundleSubstageProperties.webpackDevServerVersion !== webpackVersions.webpackDevServerVersion) {
-      logger.emitError(
-        new Error(
-          `The Webpack plugin expected to be configured with webpack-dev-server version ${webpackVersions.webpackDevServerVersion}, ` +
-            `but the configuration specifies version ${bundleSubstageProperties.webpackDevServerVersion}. ` +
-            'Are multiple versions of the Webpack plugin present?'
-        )
-      );
-    }
-
+    const logger: IScopedLogger = taskSession.logger;
+    const webpack: typeof TWebpack = await this._getWebpackAsync();
     logger.terminal.writeLine(`Using Webpack version ${webpack.version}`);
 
-    let compiler: WebpackCompiler | WebpackMultiCompiler;
+    let compiler: TWebpack.Compiler | TWebpack.MultiCompiler;
     if (Array.isArray(webpackConfiguration)) {
       if (webpackConfiguration.length === 0) {
         logger.terminal.writeLine('The webpack configuration is an empty array - nothing to do.');
         return;
       } else {
-        compiler = webpack(webpackConfiguration); /* (webpack.Compilation[]) => MultiCompiler */
+        compiler = webpack.default(webpackConfiguration); /* (webpack.Compilation[]) => MultiCompiler */
       }
     } else {
-      compiler = webpack(webpackConfiguration); /* (webpack.Compilation) => Compiler */
+      compiler = webpack.default(webpackConfiguration); /* (webpack.Compilation) => Compiler */
     }
 
-    if (buildProperties.serveMode) {
+    if (serveMode) {
       const defaultDevServerOptions: TWebpackDevServer.Configuration = {
         host: 'localhost',
         devMiddleware: {
@@ -164,7 +194,7 @@ export class WebpackPlugin implements IHeftPlugin {
           stats: {
             cached: false,
             cachedAssets: false,
-            colors: supportsColor
+            colors: heftConfiguration.terminalProvider.supportsColor
           }
         },
         client: {
@@ -215,7 +245,7 @@ export class WebpackPlugin implements IHeftPlugin {
       // WEBPACK_DEV_SERVER environment variable -- even if no APIs are accessed. This environment variable
       // causes incorrect behavior if Heft is not running in serve mode. Thus, we need to be careful to call require()
       // only if Heft is in serve mode.
-      const WebpackDevServer: typeof TWebpackDevServer = require(WEBPACK_DEV_SERVER_PACKAGE_NAME);
+      const WebpackDevServer: typeof TWebpackDevServer = await import(WEBPACK_DEV_SERVER_PACKAGE_NAME);
       // TODO: the WebpackDevServer accepts a third parameter for a logger. We should make
       // use of that to make logging cleaner
       const webpackDevServer: TWebpackDevServer = new WebpackDevServer(options, compiler);
@@ -238,11 +268,11 @@ export class WebpackPlugin implements IHeftPlugin {
         );
       }
 
-      let stats: WebpackStats | WebpackMultiStats | undefined;
-      if (buildProperties.watchMode) {
+      let stats: TWebpack.Stats | TWebpack.MultiStats | undefined;
+      if (watchMode) {
         try {
           stats = await LegacyAdapters.convertCallbackToPromise(
-            (compiler as WebpackCompiler).watch.bind(compiler),
+            (compiler as TWebpack.Compiler).watch.bind(compiler),
             {}
           );
         } catch (e) {
@@ -251,7 +281,7 @@ export class WebpackPlugin implements IHeftPlugin {
       } else {
         try {
           stats = await LegacyAdapters.convertCallbackToPromise(
-            (compiler as WebpackCompiler).run.bind(compiler)
+            (compiler as TWebpack.Compiler).run.bind(compiler)
           );
           await LegacyAdapters.convertCallbackToPromise(compiler.close.bind(compiler));
         } catch (e) {
@@ -260,21 +290,21 @@ export class WebpackPlugin implements IHeftPlugin {
       }
 
       if (stats) {
-        // eslint-disable-next-line require-atomic-updates
-        (buildProperties as IWebpackBuildStageProperties).webpackStats = stats;
-
+        if (this.accessor.onEmitStatsHook!.isUsed()) {
+          await this.accessor.onEmitStatsHook!.promise(stats);
+        }
         this._emitErrors(logger, heftConfiguration.buildFolder, stats);
       }
     }
   }
 
   private _emitErrors(
-    logger: ScopedLogger,
+    logger: IScopedLogger,
     buildFolder: string,
-    stats: WebpackStats | WebpackMultiStats
+    stats: TWebpack.Stats | TWebpack.MultiStats
   ): void {
     if (stats.hasErrors() || stats.hasWarnings()) {
-      const serializedStats: WebpackStatsCompilation = stats.toJson('errors-warnings');
+      const serializedStats: TWebpack.StatsCompilation = stats.toJson('errors-warnings');
 
       if (serializedStats.warnings) {
         for (const warning of serializedStats.warnings) {
@@ -290,25 +320,39 @@ export class WebpackPlugin implements IHeftPlugin {
     }
   }
 
-  private _normalizeError(buildFolder: string, error: WebpackStatsError): Error {
+  private _normalizeError(buildFolder: string, error: TWebpack.StatsError): Error {
     if (error instanceof Error) {
       return error;
+    } else if (error.moduleIdentifier) {
+      let lineNumber: number | undefined;
+      let columnNumber: number | undefined;
+      if (error.loc) {
+        // Format of "<line>:<columnStart>-<columnEnd>"
+        // https://webpack.js.org/api/stats/#errors-and-warnings
+        const [lineNumberRaw, columnRangeRaw] = error.loc.split(':');
+        const [startColumnRaw] = columnRangeRaw.split('-');
+        if (lineNumberRaw) {
+          lineNumber = parseInt(lineNumberRaw, 10);
+          if (isNaN(lineNumber)) {
+            lineNumber = undefined;
+          }
+        }
+        if (startColumnRaw) {
+          columnNumber = parseInt(startColumnRaw, 10);
+          if (isNaN(columnNumber)) {
+            columnNumber = undefined;
+          }
+        }
+      }
+
+      return new FileError(error.message, {
+        absolutePath: error.moduleIdentifier,
+        projectFolder: buildFolder,
+        line: lineNumber,
+        column: columnNumber
+      });
     } else {
-      let moduleName: string | undefined = error.moduleName;
-      if (!moduleName && error.moduleIdentifier) {
-        moduleName = Path.convertToSlashes(nodePath.relative(buildFolder, error.moduleIdentifier));
-      }
-
-      let formattedError: string;
-      if (error.loc && moduleName) {
-        formattedError = `${moduleName}:${error.loc} - ${error.message}`;
-      } else if (moduleName) {
-        formattedError = `${moduleName} - ${error.message}`;
-      } else {
-        formattedError = error.message;
-      }
-
-      return new Error(formattedError);
+      return new Error(error.message);
     }
   }
 }

--- a/heft-plugins/heft-webpack5-plugin/src/index.ts
+++ b/heft-plugins/heft-webpack5-plugin/src/index.ts
@@ -1,11 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-export { PLUGIN_NAME as PluginName } from './WebpackPlugin';
+export { PLUGIN_NAME as PluginName } from './Webpack5Plugin';
 
 export type {
   IWebpackConfigurationWithDevServer,
   IWebpackConfiguration,
-  IWebpackPluginAccessor,
-  IWebpackVersions
+  IWebpack5PluginAccessor
 } from './shared';

--- a/heft-plugins/heft-webpack5-plugin/src/index.ts
+++ b/heft-plugins/heft-webpack5-plugin/src/index.ts
@@ -1,18 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import type { IHeftPlugin } from '@rushstack/heft';
+export { PLUGIN_NAME as PluginName } from './WebpackPlugin';
 
-import { WebpackPlugin } from './WebpackPlugin';
-
-export {
+export type {
   IWebpackConfigurationWithDevServer,
   IWebpackConfiguration,
-  IWebpackBuildStageProperties,
-  IWebpackBundleSubstageProperties
+  IWebpackPluginAccessor,
+  IWebpackVersions
 } from './shared';
-
-/**
- * @internal
- */
-export default new WebpackPlugin() as IHeftPlugin;

--- a/heft-plugins/heft-webpack5-plugin/src/index.ts
+++ b/heft-plugins/heft-webpack5-plugin/src/index.ts
@@ -6,5 +6,7 @@ export { PLUGIN_NAME as PluginName } from './Webpack5Plugin';
 export type {
   IWebpackConfigurationWithDevServer,
   IWebpackConfiguration,
-  IWebpack5PluginAccessor
+  IWebpackConfigurationFnEnvironment,
+  IWebpack5PluginAccessor,
+  IWebpack5PluginAccessorHooks
 } from './shared';

--- a/heft-plugins/heft-webpack5-plugin/src/schemas/heft-webpack5-plugin.schema.json
+++ b/heft-plugins/heft-webpack5-plugin/src/schemas/heft-webpack5-plugin.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Webpack 5 Plugin Configuration",
+  "description": "Defines options for Webpack 5 plugin execution.",
+  "type": "object",
+
+  "additionalProperties": false,
+
+  "properties": {
+    "$schema": {
+      "description": "Part of the JSON Schema standard, this optional keyword declares the URL of the schema that the file conforms to. Editors may download the schema and use it to perform syntax highlighting.",
+      "type": "string"
+    },
+
+    "devConfigurationPath": {
+      "description": "Specifies a relative path to the Webpack dev configuration, which is used in \"serve\" mode. The default value is \"./webpack.dev.config.js\".",
+      "type": "string"
+    },
+
+    "configurationPath": {
+      "description": "Specifies a relative path to the Webpack configuration. The default value is \"./webpack.config.js\".",
+      "type": "string"
+    }
+  }
+}

--- a/heft-plugins/heft-webpack5-plugin/src/shared.ts
+++ b/heft-plugins/heft-webpack5-plugin/src/shared.ts
@@ -23,34 +23,26 @@ export type IWebpackConfiguration =
 /**
  * @public
  */
-export interface IWebpackVersions {
-  webpackVersion: string;
-  webpackDevServerVersion: string;
-}
-
-/**
- * @public
- */
-export interface IWebpackPluginAccessor {
+ export interface IWebpack5PluginAccessor {
   /**
-   * A hook that provides the versions of Webpack and Webpack Dev Server.
-   */
-  readonly onEmitWebpackVersionsHook?: AsyncParallelHook<IWebpackVersions>;
-  /**
-   * The configuration used by the Webpack plugin. This must be populated
-   * for Webpack to run. If webpackConfigFilePath is specified,
-   * this will be populated automatically with the exports of the
-   * config file referenced in that property.
+   * A hook that allows for modification of the  configuration used by the Webpack
+   * plugin. This must be populated for Webpack to run. If a webpack configuration is
+   * provided, this will be populated automatically with the exports of the config
+   * file.
    *
    * @remarks
-   * Tapable event handlers can return `null` instead of `undefined` to suppress
+   * Tapable event handlers can return `false` instead of `undefined` to suppress
    * other handlers from creating a configuration object.
    */
-  // We are inheriting this problem from Tapable's API
-  // eslint-disable-next-line @rushstack/no-new-null
-  readonly onConfigureWebpackHook?: AsyncSeriesWaterfallHook<IWebpackConfiguration | null>;
-  // We are inheriting this problem from Tapable's API
-  // eslint-disable-next-line @rushstack/no-new-null
-  readonly onAfterConfigureWebpackHook?: AsyncParallelHook<IWebpackConfiguration | null>;
-  readonly onEmitStatsHook?: AsyncParallelHook<TWebpack.Stats | TWebpack.MultiStats>;
+  readonly onConfigureWebpackHook: AsyncSeriesWaterfallHook<IWebpackConfiguration | false>;
+  /**
+   * A hook that provides the finalized configuration that will be used by Webpack.
+   * If the configuration object is supressed, this hook will not be called.
+   */
+  readonly onAfterConfigureWebpackHook: AsyncParallelHook<IWebpackConfiguration>;
+  /**
+   * A hook that provides the stats output from Webpack. If the configuration object
+   * is suppressed, this hook will not be called.
+   */
+  readonly onEmitStatsHook: AsyncParallelHook<TWebpack.Stats | TWebpack.MultiStats>;
 }

--- a/heft-plugins/heft-webpack5-plugin/src/shared.ts
+++ b/heft-plugins/heft-webpack5-plugin/src/shared.ts
@@ -4,6 +4,41 @@
 import type { Configuration as WebpackDevServerConfiguration } from 'webpack-dev-server';
 import type * as TWebpack from 'webpack';
 import type { AsyncParallelHook, AsyncSeriesWaterfallHook } from 'tapable';
+import type { IHeftTaskSession, HeftConfiguration } from '@rushstack/heft';
+
+/**
+ * The environment passed into the Webpack configuration function. Loosely based
+ * on the default Webpack environment options, specified here:
+ * https://webpack.js.org/api/cli/#environment-options
+ *
+ * @public
+ */
+export interface IWebpackConfigurationFnEnvironment {
+  /**
+   * Whether or not the run is in production mode. Synonym of
+   * IWebpackConfigurationFnEnvironment.production.
+   */
+  prod: boolean;
+  /**
+   * Whether or not the run is in production mode. Synonym of
+   * IWebpackConfigurationFnEnvironment.prod.
+   */
+  production: boolean;
+
+  // Non-standard environment options
+  /**
+   * The task session provided to the plugin.
+   */
+  taskSession: IHeftTaskSession;
+  /**
+   * The Heft configuration provided to the plugin.
+   */
+  heftConfiguration: HeftConfiguration;
+  /**
+   * The resolved Webpack package.
+   */
+  webpack: typeof TWebpack;
+}
 
 /**
  * @public
@@ -17,13 +52,12 @@ export interface IWebpackConfigurationWithDevServer extends TWebpack.Configurati
  */
 export type IWebpackConfiguration =
   | IWebpackConfigurationWithDevServer
-  | IWebpackConfigurationWithDevServer[]
-  | undefined;
+  | IWebpackConfigurationWithDevServer[];
 
 /**
  * @public
  */
- export interface IWebpack5PluginAccessor {
+export interface IWebpack5PluginAccessorHooks {
   /**
    * A hook that allows for modification of the  configuration used by the Webpack
    * plugin. This must be populated for Webpack to run. If a webpack configuration is
@@ -34,15 +68,25 @@ export type IWebpackConfiguration =
    * Tapable event handlers can return `false` instead of `undefined` to suppress
    * other handlers from creating a configuration object.
    */
-  readonly onConfigureWebpackHook: AsyncSeriesWaterfallHook<IWebpackConfiguration | false>;
+  readonly onConfigureWebpack: AsyncSeriesWaterfallHook<IWebpackConfiguration | undefined | false>;
   /**
    * A hook that provides the finalized configuration that will be used by Webpack.
    * If the configuration object is supressed, this hook will not be called.
    */
-  readonly onAfterConfigureWebpackHook: AsyncParallelHook<IWebpackConfiguration>;
+  readonly onAfterConfigureWebpack: AsyncParallelHook<IWebpackConfiguration>;
   /**
    * A hook that provides the stats output from Webpack. If the configuration object
    * is suppressed, this hook will not be called.
    */
-  readonly onEmitStatsHook: AsyncParallelHook<TWebpack.Stats | TWebpack.MultiStats>;
+  readonly onEmitStats: AsyncParallelHook<TWebpack.Stats | TWebpack.MultiStats>;
+}
+
+/**
+ * @public
+ */
+export interface IWebpack5PluginAccessor {
+  /**
+   * Hooks that are called at various points in the Webpack plugin lifecycle.
+   */
+  hooks: IWebpack5PluginAccessorHooks;
 }

--- a/heft-plugins/heft-webpack5-plugin/src/shared.ts
+++ b/heft-plugins/heft-webpack5-plugin/src/shared.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import type { Configuration as WebpackDevServerConfiguration } from 'webpack-dev-server';
 import type * as TWebpack from 'webpack';
-import type { AsyncParallelHook, AsyncSeriesWaterfallHook } from 'tapable';
+import type { Configuration as WebpackDevServerConfiguration } from 'webpack-dev-server';
+import type { AsyncParallelHook, AsyncSeriesBailHook, AsyncSeriesHook } from 'tapable';
 import type { IHeftTaskSession, HeftConfiguration } from '@rushstack/heft';
 
 /**
@@ -50,35 +50,38 @@ export interface IWebpackConfigurationWithDevServer extends TWebpack.Configurati
 /**
  * @public
  */
-export type IWebpackConfiguration =
-  | IWebpackConfigurationWithDevServer
-  | IWebpackConfigurationWithDevServer[];
+export type IWebpackConfiguration = IWebpackConfigurationWithDevServer | IWebpackConfigurationWithDevServer[];
 
 /**
  * @public
  */
 export interface IWebpack5PluginAccessorHooks {
   /**
-   * A hook that allows for modification of the  configuration used by the Webpack
-   * plugin. This must be populated for Webpack to run. If a webpack configuration is
-   * provided, this will be populated automatically with the exports of the config
-   * file.
+   * A hook that allows for loading custom configurations used by the Webpack
+   * plugin. If a webpack configuration is provided, this will be populated automatically
+   * with the exports of the config file. If a webpack configuration is not provided,
+   * one will be loaded by the Webpack plugin.
    *
    * @remarks
    * Tapable event handlers can return `false` instead of `undefined` to suppress
-   * other handlers from creating a configuration object.
+   * other handlers from creating a configuration object, and prevent webpack from running.
    */
-  readonly onConfigureWebpack: AsyncSeriesWaterfallHook<IWebpackConfiguration | undefined | false>;
+  readonly onLoadConfiguration: AsyncSeriesBailHook<never, never, never, IWebpackConfiguration | false>;
+  /**
+   * A hook that allows for modification of the loaded configuration used by the Webpack
+   * plugin. If no configuration was loaded, this hook will not be called.
+   */
+  readonly onConfigure: AsyncSeriesHook<IWebpackConfiguration, never, never>;
   /**
    * A hook that provides the finalized configuration that will be used by Webpack.
-   * If the configuration object is supressed, this hook will not be called.
+   * If no configuration was loaded, this hook will not be called.
    */
-  readonly onAfterConfigureWebpack: AsyncParallelHook<IWebpackConfiguration>;
+  readonly onAfterConfigure: AsyncParallelHook<IWebpackConfiguration, never, never>;
   /**
-   * A hook that provides the stats output from Webpack. If the configuration object
-   * is suppressed, this hook will not be called.
+   * A hook that provides the stats output from Webpack. If no configuration is loaded,
+   * this hook will not be called.
    */
-  readonly onEmitStats: AsyncParallelHook<TWebpack.Stats | TWebpack.MultiStats>;
+  readonly onEmitStats: AsyncParallelHook<TWebpack.Stats | TWebpack.MultiStats, never, never>;
 }
 
 /**

--- a/heft-plugins/heft-webpack5-plugin/src/shared.ts
+++ b/heft-plugins/heft-webpack5-plugin/src/shared.ts
@@ -2,13 +2,13 @@
 // See LICENSE in the project root for license information.
 
 import type { Configuration as WebpackDevServerConfiguration } from 'webpack-dev-server';
-import type * as webpack from 'webpack';
-import type { IBuildStageProperties, IBundleSubstageProperties } from '@rushstack/heft';
+import type * as TWebpack from 'webpack';
+import type { AsyncParallelHook, AsyncSeriesWaterfallHook } from 'tapable';
 
 /**
  * @public
  */
-export interface IWebpackConfigurationWithDevServer extends webpack.Configuration {
+export interface IWebpackConfigurationWithDevServer extends TWebpack.Configuration {
   devServer?: WebpackDevServerConfiguration;
 }
 
@@ -23,7 +23,19 @@ export type IWebpackConfiguration =
 /**
  * @public
  */
-export interface IWebpackBundleSubstageProperties extends IBundleSubstageProperties {
+export interface IWebpackVersions {
+  webpackVersion: string;
+  webpackDevServerVersion: string;
+}
+
+/**
+ * @public
+ */
+export interface IWebpackPluginAccessor {
+  /**
+   * A hook that provides the versions of Webpack and Webpack Dev Server.
+   */
+  readonly onEmitWebpackVersionsHook?: AsyncParallelHook<IWebpackVersions>;
   /**
    * The configuration used by the Webpack plugin. This must be populated
    * for Webpack to run. If webpackConfigFilePath is specified,
@@ -36,12 +48,9 @@ export interface IWebpackBundleSubstageProperties extends IBundleSubstagePropert
    */
   // We are inheriting this problem from Tapable's API
   // eslint-disable-next-line @rushstack/no-new-null
-  webpackConfiguration?: webpack.Configuration | webpack.Configuration[] | null;
-}
-
-/**
- * @public
- */
-export interface IWebpackBuildStageProperties extends IBuildStageProperties {
-  webpackStats?: webpack.Stats | webpack.MultiStats;
+  readonly onConfigureWebpackHook?: AsyncSeriesWaterfallHook<IWebpackConfiguration | null>;
+  // We are inheriting this problem from Tapable's API
+  // eslint-disable-next-line @rushstack/no-new-null
+  readonly onAfterConfigureWebpackHook?: AsyncParallelHook<IWebpackConfiguration | null>;
+  readonly onEmitStatsHook?: AsyncParallelHook<TWebpack.Stats | TWebpack.MultiStats>;
 }

--- a/heft-plugins/heft-webpack5-plugin/src/webpack-dev-middleware-workaround.d.ts
+++ b/heft-plugins/heft-webpack5-plugin/src/webpack-dev-middleware-workaround.d.ts
@@ -1,9 +1,0 @@
-// The webpack-dev-middleware@5.3.1 project has a phantom dependency on @types/node
-// and so "npm install" chooses the "*" latest version.  As a result, their index.d.ts
-// has a reference to fs.StatSyncFn which is new in @types/node@16.  As of this writing
-// Node 12 is still LTS so we need to support it.
-// Upstream issue: https://github.com/webpack/webpack-dev-middleware/issues/1194
-declare module 'fs' {
-  // eslint-disable-next-line
-  export type StatSyncFn = any;
-}


### PR DESCRIPTION
## Summary

Updates the Webpack 4 and Webpack 5 Heft plugins to be compatible with multi-phase Heft. No "rush update" performed as this change will not produce a passing build without other packages being converted.
