### PR TITLE
Add incremental build support for Webpack plugins

### DIFF
--- a/apps/heft/src/cli/HeftActionRunner.ts
+++ b/apps/heft/src/cli/HeftActionRunner.ts
@@ -303,16 +303,9 @@ export class HeftActionRunner {
       description: 'Use the specified locale for this run, if applicable.'
     });
 
-    let serveFlag: CommandLineFlagParameter | undefined;
     let cleanFlag: CommandLineFlagParameter | undefined;
     let cleanCacheFlag: CommandLineFlagParameter | undefined;
-    if (this._action.watch) {
-      // Only enable the serve flag in watch mode
-      serveFlag = parameterProvider.defineFlagParameter({
-        parameterLongName: Constants.serveParameterLongName,
-        description: 'If specified, serve the output. This flag can only be used with watch-enabled actions.'
-      });
-    } else {
+    if (!this._action.watch) {
       // Only enable the clean flags in non-watch mode
       cleanFlag = parameterProvider.defineFlagParameter({
         parameterLongName: Constants.cleanParameterLongName,
@@ -332,7 +325,6 @@ export class HeftActionRunner {
       getIsProduction: () => productionFlag.value,
       getIsWatch: () => this._action.watch,
       getLocales: () => localesParameter.values,
-      getIsServe: () => !!serveFlag?.value,
       getIsClean: () => !!cleanFlag?.value,
       getIsCleanCache: () => !!cleanCacheFlag?.value
     });

--- a/apps/heft/src/pluginFramework/HeftParameterManager.ts
+++ b/apps/heft/src/pluginFramework/HeftParameterManager.ts
@@ -73,11 +73,6 @@ export interface IHeftDefaultParameters {
    * Whether or not the Heft action is running in watch mode.
    */
   readonly watch: boolean;
-
-  /**
-   * Whether or not the `--serve` flag was passed to the Heft action.
-   */
-  readonly serve: boolean;
 }
 
 /**
@@ -143,7 +138,6 @@ export interface IHeftParameterManagerOptions {
   getIsVerbose: () => boolean;
   getIsProduction: () => boolean;
   getIsWatch: () => boolean;
-  getIsServe: () => boolean;
   getLocales: () => Iterable<string>;
 }
 
@@ -171,8 +165,7 @@ export class HeftParameterManager {
         verbose: this._options.getIsVerbose(),
         production: this._options.getIsProduction(),
         locales: this._options.getLocales(),
-        watch: this._options.getIsWatch(),
-        serve: this._options.getIsServe()
+        watch: this._options.getIsWatch()
       };
     }
     return this._defaultParameters;

--- a/apps/heft/src/utilities/Constants.ts
+++ b/apps/heft/src/utilities/Constants.ts
@@ -22,8 +22,6 @@ export class Constants {
 
   public static productionParameterLongName: string = '--production';
 
-  public static serveParameterLongName: string = '--serve';
-
   public static toParameterLongName: string = '--to';
 
   public static toParameterShortName: string = '-t';

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1638,6 +1638,7 @@ importers:
 
   ../../heft-plugins/heft-webpack4-plugin:
     specifiers:
+      '@rushstack/debug-certificate-manager': workspace:*
       '@rushstack/eslint-config': workspace:*
       '@rushstack/heft': workspace:*
       '@rushstack/heft-node-rig': workspace:*
@@ -1649,6 +1650,7 @@ importers:
       webpack: ~4.44.2
       webpack-dev-server: ~4.9.3
     dependencies:
+      '@rushstack/debug-certificate-manager': link:../../libraries/debug-certificate-manager
       '@rushstack/node-core-library': link:../../libraries/node-core-library
       '@types/tapable': 1.0.6
       tapable: 1.1.3
@@ -1663,6 +1665,7 @@ importers:
 
   ../../heft-plugins/heft-webpack5-plugin:
     specifiers:
+      '@rushstack/debug-certificate-manager': workspace:*
       '@rushstack/eslint-config': workspace:*
       '@rushstack/heft': workspace:*
       '@rushstack/heft-node-rig': workspace:*
@@ -1673,6 +1676,7 @@ importers:
       webpack: ~5.68.0
       webpack-dev-server: ~4.9.3
     dependencies:
+      '@rushstack/debug-certificate-manager': link:../../libraries/debug-certificate-manager
       '@rushstack/node-core-library': link:../../libraries/node-core-library
       '@types/tapable': 1.0.6
       tapable: 1.1.3

--- a/common/reviews/api/heft.api.md
+++ b/common/reviews/api/heft.api.md
@@ -120,7 +120,6 @@ export interface IHeftDefaultParameters {
     readonly debug: boolean;
     readonly locales: Iterable<string>;
     readonly production: boolean;
-    readonly serve: boolean;
     readonly verbose: boolean;
     readonly watch: boolean;
 }

--- a/heft-plugins/heft-webpack4-plugin/heft-plugin.json
+++ b/heft-plugins/heft-webpack4-plugin/heft-plugin.json
@@ -5,7 +5,16 @@
     {
       "pluginName": "Webpack4Plugin",
       "entryPoint": "./lib/Webpack4Plugin",
-      "optionsSchema": "./lib/schemas/heft-webpack4-plugin.schema.json"
+      "optionsSchema": "./lib/schemas/heft-webpack4-plugin.schema.json",
+
+      "parameterScope": "webpack4",
+      "parameters": [
+        {
+          "longName": "--serve",
+          "parameterKind": "flag",
+          "description": "Start a local web server for testing purposes using webpack-dev-server.  This parameter is only available when running in watch mode."
+        }
+      ]
     }
   ]
 }

--- a/heft-plugins/heft-webpack4-plugin/package.json
+++ b/heft-plugins/heft-webpack4-plugin/package.json
@@ -28,6 +28,7 @@
     "webpack": "~4.44.2"
   },
   "dependencies": {
+    "@rushstack/debug-certificate-manager": "workspace:*",
     "@rushstack/node-core-library": "workspace:*",
     "@types/tapable": "1.0.6",
     "tapable": "1.1.3",

--- a/heft-plugins/heft-webpack4-plugin/src/Webpack4Plugin.ts
+++ b/heft-plugins/heft-webpack4-plugin/src/Webpack4Plugin.ts
@@ -321,7 +321,7 @@ export default class Webpack4Plugin implements IHeftTaskPlugin<IWebpackPluginOpt
             if (addressInfo) {
               const address: string =
                 typeof addressInfo === 'string' ? addressInfo : `${addressInfo.address}:${addressInfo.port}`;
-              taskSession.logger.terminal.writeLine(`Started Webpack Dev Server at ${address}`);
+              taskSession.logger.terminal.writeLine(`Started Webpack Dev Server at https://${address}`);
             }
           }
         };

--- a/heft-plugins/heft-webpack4-plugin/src/Webpack4Plugin.ts
+++ b/heft-plugins/heft-webpack4-plugin/src/Webpack4Plugin.ts
@@ -1,17 +1,20 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+import type { AddressInfo } from 'net';
 import type * as TWebpack from 'webpack';
 import type TWebpackDevServer from 'webpack-dev-server';
-import { AsyncParallelHook, AsyncSeriesBailHook, AsyncSeriesHook } from 'tapable';
-import { LegacyAdapters } from '@rushstack/node-core-library';
+import { AsyncParallelHook, AsyncSeriesBailHook, AsyncSeriesHook, type SyncBailHook } from 'tapable';
+import { CertificateManager, type ICertificate } from '@rushstack/debug-certificate-manager';
+import { InternalError, LegacyAdapters } from '@rushstack/node-core-library';
 import type {
   HeftConfiguration,
   IHeftTaskSession,
   IHeftTaskCleanHookOptions,
   IHeftTaskPlugin,
   IHeftTaskRunHookOptions,
-  IScopedLogger
+  IScopedLogger,
+  IHeftTaskRunIncrementalHookOptions
 } from '@rushstack/heft';
 
 import type {
@@ -21,7 +24,29 @@ import type {
 } from './shared';
 import { WebpackConfigurationLoader } from './WebpackConfigurationLoader';
 
-export interface IWebpack4PluginOptions {
+type ExtendedCompiler = TWebpack.Compiler & {
+  hooks: TWebpack.Compiler['hooks'] & {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    infrastructureLog: SyncBailHook<string, string, any[]>;
+  };
+  watching: TWebpack.Watching;
+};
+
+type ExtendedMultiCompiler = TWebpack.MultiCompiler & {
+  compilers: ExtendedCompiler[];
+  hooks: TWebpack.Compiler['hooks'] & {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    infrastructureLog: SyncBailHook<string, string, any[]>;
+  };
+  watching: TWebpack.MultiWatching;
+};
+
+type ExtendedWatching = TWebpack.Watching & {
+  resume: () => void;
+  suspend: () => void;
+};
+
+export interface IWebpackPluginOptions {
   devConfigurationPath: string | undefined;
   configurationPath: string | undefined;
 }
@@ -30,16 +55,22 @@ export interface IWebpack4PluginOptions {
  * @public
  */
 export const PLUGIN_NAME: 'Webpack4Plugin' = 'Webpack4Plugin';
+const WEBPACK_PACKAGE_NAME: 'webpack' = 'webpack';
 const WEBPACK_DEV_SERVER_PACKAGE_NAME: 'webpack-dev-server' = 'webpack-dev-server';
 const WEBPACK_DEV_SERVER_ENV_VAR_NAME: 'WEBPACK_DEV_SERVER' = 'WEBPACK_DEV_SERVER';
+const WEBPACK_DEV_MIDDLEWARE_PACKAGE_NAME: 'webpack-dev-middleware' = 'webpack-dev-middleware';
 const UNINITIALIZED: 'UNINITIALIZED' = 'UNINITIALIZED';
 
 /**
  * @internal
  */
-export default class Webpack4Plugin implements IHeftTaskPlugin<IWebpack4PluginOptions> {
+export default class Webpack4Plugin implements IHeftTaskPlugin<IWebpackPluginOptions> {
   private _webpack: typeof TWebpack | undefined;
+  private _webpackCompiler: ExtendedCompiler | ExtendedMultiCompiler | undefined;
   private _webpackConfiguration: IWebpackConfiguration | undefined | typeof UNINITIALIZED = UNINITIALIZED;
+  private _webpackWatchers: ExtendedWatching[] | undefined;
+  private _webpackCompilationDonePromise: Promise<void> | undefined;
+  private _webpackCompilationDonePromiseResolveFn: (() => void) | undefined;
 
   public readonly accessor: IWebpackPluginAccessor = {
     hooks: {
@@ -53,35 +84,12 @@ export default class Webpack4Plugin implements IHeftTaskPlugin<IWebpack4PluginOp
   public apply(
     taskSession: IHeftTaskSession,
     heftConfiguration: HeftConfiguration,
-    options: IWebpack4PluginOptions
+    options: IWebpackPluginOptions
   ): void {
-    // These get set in the run hook and used in the onConfigureWebpackHook
-    let production: boolean;
-    let serveMode: boolean;
-    let watchMode: boolean;
-
-    // TODO: Move this into _getWebpackConfigurationAsync once default parameters are moved
-    const getDefaultWebpackConfigurationFn: () => Promise<IWebpackConfiguration | undefined> = async () => {
-      taskSession.logger.terminal.writeVerboseLine('Loading default Webpack configuration');
-      const configurationLoader: WebpackConfigurationLoader = new WebpackConfigurationLoader(
-        taskSession.logger,
-        production,
-        serveMode
-      );
-      return await configurationLoader.tryLoadWebpackConfigurationAsync({
-        ...options,
-        taskSession,
-        heftConfiguration,
-        loadWebpackAsyncFn: this._loadWebpackAsync.bind(this)
-      });
-    };
-
     taskSession.hooks.clean.tapPromise(PLUGIN_NAME, async (cleanOptions: IHeftTaskCleanHookOptions) => {
-      production = taskSession.parameters.production;
-
       // Obtain the finalized webpack configuration
       const webpackConfiguration: IWebpackConfiguration | undefined =
-        await this._getWebpackConfigurationAsync(getDefaultWebpackConfigurationFn);
+        await this._getWebpackConfigurationAsync(taskSession, heftConfiguration, options);
       if (webpackConfiguration) {
         const webpackConfigurationArray: IWebpackConfigurationWithDevServer[] = Array.isArray(
           webpackConfiguration
@@ -101,37 +109,53 @@ export default class Webpack4Plugin implements IHeftTaskPlugin<IWebpack4PluginOp
     });
 
     taskSession.hooks.run.tapPromise(PLUGIN_NAME, async (runOptions: IHeftTaskRunHookOptions) => {
-      production = taskSession.parameters.production;
-      // TODO: Support watch mode
-      watchMode = false;
-      // TODO: Support serve mode
-      serveMode = false;
-
-      // Run webpack with the finalized webpack configuration
-      const webpackConfiguration: IWebpackConfiguration | undefined =
-        await this._getWebpackConfigurationAsync(getDefaultWebpackConfigurationFn);
-      await this._runWebpackAsync(taskSession, heftConfiguration, webpackConfiguration, serveMode, watchMode);
+      await this._runWebpackAsync(taskSession, heftConfiguration, options);
     });
-  }
 
-  private async _loadWebpackAsync(): Promise<typeof TWebpack> {
-    if (!this._webpack) {
-      this._webpack = await import('webpack');
-    }
-    return this._webpack;
+    taskSession.hooks.runIncremental.tapPromise(
+      PLUGIN_NAME,
+      async (runOptions: IHeftTaskRunIncrementalHookOptions) => {
+        await this._runWebpackWatchAsync(taskSession, heftConfiguration, options);
+      }
+    );
   }
 
   private async _getWebpackConfigurationAsync(
-    getDefaultWebpackConfigurationFn: () => Promise<IWebpackConfiguration | undefined>
+    taskSession: IHeftTaskSession,
+    heftConfiguration: HeftConfiguration,
+    options: IWebpackPluginOptions
   ): Promise<IWebpackConfiguration | undefined> {
     if (this._webpackConfiguration === UNINITIALIZED) {
       // Obtain the webpack configuration by calling into the hook. If undefined
       // is returned, load the default Webpack configuration.
-      const webpackConfiguration: IWebpackConfiguration | false | undefined =
-        (await this.accessor.hooks.onLoadConfiguration.promise()) ??
-        (await getDefaultWebpackConfigurationFn());
+      taskSession.logger.terminal.writeVerboseLine(
+        'Attempting to load Webpack configuration via external plugins'
+      );
+      let webpackConfiguration: IWebpackConfiguration | false | undefined =
+        await this.accessor.hooks.onLoadConfiguration.promise();
+      if (webpackConfiguration === undefined) {
+        taskSession.logger.terminal.writeVerboseLine('Attempt to load the default Webpack configuration');
+        const configurationLoader: WebpackConfigurationLoader = new WebpackConfigurationLoader(
+          taskSession.logger,
+          taskSession.parameters.production,
+          taskSession.parameters.watch && taskSession.parameters.serve
+        );
+        webpackConfiguration = await configurationLoader.tryLoadWebpackConfigurationAsync({
+          ...options,
+          taskSession,
+          heftConfiguration,
+          loadWebpackAsyncFn: this._loadWebpackAsync.bind(this)
+        });
+      }
 
-      if (!webpackConfiguration) {
+      if (webpackConfiguration === false) {
+        taskSession.logger.terminal.writeLine('Webpack disabled by external plugin');
+        this._webpackConfiguration = undefined;
+      } else if (
+        webpackConfiguration === undefined ||
+        (Array.isArray(webpackConfiguration) && webpackConfiguration.length === 0)
+      ) {
+        taskSession.logger.terminal.writeLine('No Webpack configuration found');
         this._webpackConfiguration = undefined;
       } else {
         if (this.accessor.hooks.onConfigure.isUsed()) {
@@ -148,130 +172,255 @@ export default class Webpack4Plugin implements IHeftTaskPlugin<IWebpack4PluginOp
     return this._webpackConfiguration;
   }
 
+  private async _loadWebpackAsync(): Promise<typeof TWebpack> {
+    if (!this._webpack) {
+      // Allow this to fail if webpack is not installed
+      this._webpack = await import(WEBPACK_PACKAGE_NAME);
+    }
+    return this._webpack!;
+  }
+
+  private async _getWebpackCompilerAsync(
+    taskSession: IHeftTaskSession,
+    webpackConfiguration: IWebpackConfiguration
+  ): Promise<ExtendedCompiler | ExtendedMultiCompiler> {
+    if (!this._webpackCompiler) {
+      const webpack: typeof TWebpack = await this._loadWebpackAsync();
+      taskSession.logger.terminal.writeLine(`Using Webpack version ${webpack.version}`);
+      this._webpackCompiler = Array.isArray(webpackConfiguration)
+        ? (webpack.default(
+            webpackConfiguration
+          ) as ExtendedMultiCompiler) /* (webpack.Compilation[]) => MultiCompiler */
+        : (webpack.default(webpackConfiguration) as ExtendedCompiler); /* (webpack.Compilation) => Compiler */
+    }
+    return this._webpackCompiler;
+  }
+
   private async _runWebpackAsync(
     taskSession: IHeftTaskSession,
     heftConfiguration: HeftConfiguration,
-    webpackConfiguration: IWebpackConfiguration | undefined,
-    serveMode: boolean,
-    watchMode: boolean
+    options: IWebpackPluginOptions
   ): Promise<void> {
-    const logger: IScopedLogger = taskSession.logger;
+    this._validateEnvironmentVariable(taskSession);
+    if (taskSession.parameters.watch || taskSession.parameters.serve) {
+      // Should never happen, but just in case
+      throw new InternalError('Cannot run Webpack in compilation mode when watch mode is enabled');
+    }
 
+    // Load the config and compiler, and return if there is no config found
+    const webpackConfiguration: IWebpackConfiguration | undefined = await this._getWebpackConfigurationAsync(
+      taskSession,
+      heftConfiguration,
+      options
+    );
     if (!webpackConfiguration) {
-      logger.terminal.writeLine('Webpack configuration not provided, running Webpack skipped');
       return;
     }
+    const compiler: ExtendedCompiler | ExtendedMultiCompiler = await this._getWebpackCompilerAsync(
+      taskSession,
+      webpackConfiguration
+    );
+    taskSession.logger.terminal.writeLine('Running Webpack compilation');
 
-    const webpack: typeof TWebpack = await this._loadWebpackAsync();
-    logger.terminal.writeLine(`Using Webpack version ${webpack.version}`);
-
-    let compiler: TWebpack.Compiler | TWebpack.MultiCompiler;
-    if (Array.isArray(webpackConfiguration)) {
-      if (webpackConfiguration.length === 0) {
-        logger.terminal.writeLine('The webpack configuration received is an empty array - nothing to do.');
-        return;
-      } else {
-        compiler = webpack.default(webpackConfiguration); /* (webpack.Compilation[]) => MultiCompiler */
-      }
-    } else {
-      compiler = webpack.default(webpackConfiguration); /* (webpack.Compilation) => Compiler */
+    // Run the webpack compiler
+    let stats: TWebpack.Stats | TWebpack.MultiStats | undefined;
+    try {
+      stats = await LegacyAdapters.convertCallbackToPromise(
+        (compiler as TWebpack.Compiler).run.bind(compiler)
+      );
+    } catch (e) {
+      taskSession.logger.emitError(e as Error);
     }
 
-    if (serveMode) {
-      const defaultDevServerOptions: TWebpackDevServer.Configuration = {
-        host: 'localhost',
-        devMiddleware: {
-          publicPath: '/',
-          stats: {
-            cached: false,
-            cachedAssets: false,
-            colors: heftConfiguration.terminalProvider.supportsColor
-          }
-        },
-        client: {
-          logging: 'info'
-        },
-        port: 8080
+    // Emit the errors from the stats object, if present
+    if (stats) {
+      this._emitErrors(taskSession.logger, stats);
+      if (this.accessor.hooks.onEmitStats.isUsed()) {
+        await this.accessor.hooks.onEmitStats.promise(stats);
+      }
+    }
+  }
+
+  private async _runWebpackWatchAsync(
+    taskSession: IHeftTaskSession,
+    heftConfiguration: HeftConfiguration,
+    options: IWebpackPluginOptions
+  ): Promise<void> {
+    // Save a handle to the original promise, since the this-scoped promise will be replaced whenever
+    // the compilation completes.
+    let webpackCompilationDonePromise: Promise<void> | undefined = this._webpackCompilationDonePromise;
+
+    if (!this._webpackWatchers) {
+      this._validateEnvironmentVariable(taskSession);
+      if (!taskSession.parameters.watch) {
+        // Should never happen, but just in case
+        throw new InternalError('Cannot run Webpack in watch mode when compilation mode is enabled');
+      }
+
+      // Load the config and compiler, and return if there is no config found
+      const webpackConfiguration: IWebpackConfiguration | undefined =
+        await this._getWebpackConfigurationAsync(taskSession, heftConfiguration, options);
+      if (!webpackConfiguration) {
+        return;
+      }
+
+      // Get the compiler which will be used for both serve and watch mode
+      const compiler: ExtendedCompiler | ExtendedMultiCompiler = await this._getWebpackCompilerAsync(
+        taskSession,
+        webpackConfiguration
+      );
+
+      // Set up the hook to detect when the watcher completes the watcher compilation. We will also log out
+      // errors from the compilation if present from the output stats object.
+      this._webpackCompilationDonePromise = new Promise((resolve: () => void) => {
+        this._webpackCompilationDonePromiseResolveFn = resolve;
+      });
+      webpackCompilationDonePromise = this._webpackCompilationDonePromise;
+      compiler.hooks.done.tap(PLUGIN_NAME, (stats?: TWebpack.Stats | TWebpack.MultiStats) => {
+        this._webpackCompilationDonePromiseResolveFn!();
+        this._webpackCompilationDonePromise = new Promise((resolve: () => void) => {
+          this._webpackCompilationDonePromiseResolveFn = resolve;
+        });
+        if (stats) {
+          this._emitErrors(taskSession.logger, stats);
+        }
+      });
+
+      // TWebpack.Compiler and TWebpack.MultiCompiler in Webpack 4 do not allow you to access the running
+      // watcher, so we need to patch the method to set the watcher on the parent object.
+      const originalWatch: TWebpack.Compiler['watch'] | TWebpack.MultiCompiler['watch'] =
+        compiler.watch.bind(compiler);
+      compiler.watch = (
+        watchOptions: TWebpack.ICompiler.WatchOptions,
+        handler: TWebpack.ICompiler.Handler & TWebpack.ICompiler.MultiHandler
+      ) => {
+        const watcher: TWebpack.Watching | TWebpack.MultiWatching = originalWatch(watchOptions, handler);
+        compiler.watching = watcher;
+        return watcher;
       };
 
-      let options: TWebpackDevServer.Configuration;
-      if (Array.isArray(webpackConfiguration)) {
-        const devServerOptions: TWebpackDevServer.Configuration[] = webpackConfiguration
-          .map((configuration) => configuration.devServer)
-          .filter((devServer): devServer is TWebpackDevServer.Configuration => !!devServer);
-        if (devServerOptions.length > 1) {
-          logger.emitWarning(
-            new Error(`Detected multiple webpack devServer configurations, using the first one.`)
-          );
-        }
+      // Determine how we will run the compiler. When serving, we will run the compiler
+      // via the webpack-dev-server. Otherwise, we will run the compiler directly.
+      if (taskSession.parameters.serve) {
+        const defaultDevServerOptions: TWebpackDevServer.Configuration = {
+          host: 'localhost',
+          devMiddleware: {
+            publicPath: '/',
+            stats: {
+              cached: false,
+              cachedAssets: false,
+              colors: heftConfiguration.terminalProvider.supportsColor
+            }
+          },
+          client: {
+            logging: 'info'
+          },
+          port: 8080,
+          onListening: (server: TWebpackDevServer) => {
+            const addressInfo: AddressInfo | string | undefined = server.server?.address() as AddressInfo;
+            if (addressInfo) {
+              const address: string =
+                typeof addressInfo === 'string' ? addressInfo : `${addressInfo.address}:${addressInfo.port}`;
+              taskSession.logger.terminal.writeLine(`Started Webpack Dev Server at ${address}`);
+            }
+          }
+        };
 
-        if (devServerOptions.length > 0) {
-          options = { ...defaultDevServerOptions, ...devServerOptions[0] };
+        // Obtain the devServerOptions from the webpack configuration, and combine with the default options
+        let devServerOptions: TWebpackDevServer.Configuration;
+        if (Array.isArray(webpackConfiguration)) {
+          const filteredDevServerOptions: TWebpackDevServer.Configuration[] = webpackConfiguration
+            .map((configuration) => configuration.devServer)
+            .filter((devServer): devServer is TWebpackDevServer.Configuration => !!devServer);
+          if (filteredDevServerOptions.length > 1) {
+            taskSession.logger.emitWarning(
+              new Error(`Detected multiple webpack devServer configurations, using the first one.`)
+            );
+          }
+          devServerOptions = { ...defaultDevServerOptions, ...filteredDevServerOptions[0] };
         } else {
-          options = defaultDevServerOptions;
+          devServerOptions = { ...defaultDevServerOptions, ...webpackConfiguration.devServer };
         }
-      } else {
-        options = { ...defaultDevServerOptions, ...webpackConfiguration.devServer };
-      }
 
-      // Register a plugin to callback after webpack is done with the first compilation
-      // so we can move on to post-build
-      let firstCompilationDoneCallback: (() => void) | undefined;
-      compiler.hooks.done.tap(PLUGIN_NAME, () => {
-        if (firstCompilationDoneCallback) {
-          firstCompilationDoneCallback();
-          firstCompilationDoneCallback = undefined;
-        }
-      });
-
-      // The webpack-dev-server package has a design flaw, where merely loading its package will set the
-      // WEBPACK_DEV_SERVER environment variable -- even if no APIs are accessed. This environment variable
-      // causes incorrect behavior if Heft is not running in serve mode. Thus, we need to be careful to call
-      // require() only if Heft is in serve mode.
-      const WebpackDevServer: typeof TWebpackDevServer = await import(WEBPACK_DEV_SERVER_PACKAGE_NAME);
-      const webpackDevServer: TWebpackDevServer = new WebpackDevServer(options, compiler);
-
-      await new Promise<void>((resolve: () => void, reject: (error: Error) => void) => {
-        firstCompilationDoneCallback = resolve;
-        webpackDevServer.start().catch(reject);
-      });
-    } else {
-      if (process.env[WEBPACK_DEV_SERVER_ENV_VAR_NAME]) {
-        logger.emitWarning(
-          new Error(
-            `The "${WEBPACK_DEV_SERVER_ENV_VAR_NAME}" environment variable is set, ` +
-              'which will cause problems when webpack is not running in serve mode. ' +
-              `(Did a dependency inadvertently load the "${WEBPACK_DEV_SERVER_PACKAGE_NAME}" package?)`
-          )
+        // Add the certificate and key to the devServerOptions
+        const certificateManager: CertificateManager = new CertificateManager();
+        const certificate: ICertificate = await certificateManager.ensureCertificateAsync(
+          true,
+          taskSession.logger.terminal
         );
-      }
+        devServerOptions = {
+          ...devServerOptions,
+          server: {
+            type: 'https',
+            options: {
+              key: certificate.pemKey,
+              cert: certificate.pemCertificate
+            }
+          }
+        };
 
-      let stats: TWebpack.Stats | TWebpack.compilation.MultiStats | undefined;
-      if (watchMode) {
-        try {
-          stats = await LegacyAdapters.convertCallbackToPromise(
-            (compiler as TWebpack.Compiler).watch.bind(compiler),
-            {}
-          );
-        } catch (e) {
-          logger.emitError(e as Error);
-        }
+        // Since the webpack-dev-server does not return infrastructure errors via a callback like
+        // compiler.watch(...), we will need to intercept them and log them ourselves.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        compiler.hooks.infrastructureLog.tap(PLUGIN_NAME, (name: string, type: string, args: any[]) => {
+          if (name === WEBPACK_DEV_MIDDLEWARE_PACKAGE_NAME && type === 'error') {
+            const error: Error | undefined = args[0];
+            if (error) {
+              taskSession.logger.emitError(error);
+            }
+          }
+          return true;
+        });
+
+        // The webpack-dev-server package has a design flaw, where merely loading its package will set the
+        // WEBPACK_DEV_SERVER environment variable -- even if no APIs are accessed. This environment variable
+        // causes incorrect behavior if Heft is not running in serve mode. Thus, we need to be careful to call
+        // require() only if Heft is in serve mode.
+        taskSession.logger.terminal.writeLine('Starting webpack-dev-server');
+        const WebpackDevServer: typeof TWebpackDevServer = (await import(WEBPACK_DEV_SERVER_PACKAGE_NAME))
+          .default;
+        const webpackDevServer: TWebpackDevServer = new WebpackDevServer(devServerOptions, compiler);
+        await webpackDevServer.start();
       } else {
-        try {
-          stats = await LegacyAdapters.convertCallbackToPromise(
-            (compiler as TWebpack.Compiler).run.bind(compiler)
-          );
-        } catch (e) {
-          logger.emitError(e as Error);
-        }
+        // Create the watcher. Compilation will start immediately after invoking watch().
+        taskSession.logger.terminal.writeLine('Starting Webpack watcher');
+        compiler.watch({}, (error?: Error | null) => {
+          if (error) {
+            taskSession.logger.emitError(error);
+          }
+        });
       }
 
-      if (stats) {
-        this._emitErrors(logger, stats);
-        if (this.accessor.hooks.onEmitStats.isUsed()) {
-          await this.accessor.hooks.onEmitStats.promise(stats);
+      // Store the watchers to be used for suspend/resume
+      this._webpackWatchers = (compiler as ExtendedMultiCompiler).compilers?.map(
+        (compiler: ExtendedCompiler) => {
+          return compiler.watching as ExtendedWatching;
         }
-      }
+      ) ?? [(compiler as ExtendedCompiler).watching as ExtendedWatching];
+    }
+
+    // Resume the compilation, wait for the compilation to complete, then suspend the watchers until the
+    // next iteration. Even if there are no changes, the promise should resolve since resuming from a
+    // suspended state invalidates the state of the watcher.
+    taskSession.logger.terminal.writeLine('Running incremental Webpack compilation');
+    for (const watcher of this._webpackWatchers) {
+      watcher.resume();
+    }
+    await webpackCompilationDonePromise;
+    for (const watcher of this._webpackWatchers) {
+      watcher.suspend();
+    }
+  }
+
+  private _validateEnvironmentVariable(taskSession: IHeftTaskSession): void {
+    if (!taskSession.parameters.serve && process.env[WEBPACK_DEV_SERVER_ENV_VAR_NAME]) {
+      taskSession.logger.emitWarning(
+        new Error(
+          `The "${WEBPACK_DEV_SERVER_ENV_VAR_NAME}" environment variable is set, ` +
+            'which will cause problems when webpack is not running in serve mode. ' +
+            `(Did a dependency inadvertently load the "${WEBPACK_DEV_SERVER_PACKAGE_NAME}" package?)`
+        )
+      );
     }
   }
 

--- a/heft-plugins/heft-webpack4-plugin/src/Webpack4Plugin.ts
+++ b/heft-plugins/heft-webpack4-plugin/src/Webpack4Plugin.ts
@@ -353,22 +353,24 @@ export default class Webpack4Plugin implements IHeftTaskPlugin<IWebpackPluginOpt
           devServerOptions = { ...defaultDevServerOptions, ...webpackConfiguration.devServer };
         }
 
-        // Add the certificate and key to the devServerOptions
-        const certificateManager: CertificateManager = new CertificateManager();
-        const certificate: ICertificate = await certificateManager.ensureCertificateAsync(
-          true,
-          taskSession.logger.terminal
-        );
-        devServerOptions = {
-          ...devServerOptions,
-          server: {
-            type: 'https',
-            options: {
-              key: certificate.pemKey,
-              cert: certificate.pemCertificate
+        // Add the certificate and key to the devServerOptions if these fields don't already have values
+        if (!devServerOptions.server) {
+          const certificateManager: CertificateManager = new CertificateManager();
+          const certificate: ICertificate = await certificateManager.ensureCertificateAsync(
+            true,
+            taskSession.logger.terminal
+          );
+          devServerOptions = {
+            ...devServerOptions,
+            server: {
+              type: 'https',
+              options: {
+                key: certificate.pemKey,
+                cert: certificate.pemCertificate
+              }
             }
-          }
-        };
+          };
+        }
 
         // Since the webpack-dev-server does not return infrastructure errors via a callback like
         // compiler.watch(...), we will need to intercept them and log them ourselves.

--- a/heft-plugins/heft-webpack4-plugin/src/WebpackConfigurationLoader.ts
+++ b/heft-plugins/heft-webpack4-plugin/src/WebpackConfigurationLoader.ts
@@ -6,7 +6,7 @@ import type * as TWebpack from 'webpack';
 import { FileSystem } from '@rushstack/node-core-library';
 import type { IScopedLogger, IHeftTaskSession, HeftConfiguration } from '@rushstack/heft';
 
-import type { IWebpack4PluginOptions } from './Webpack4Plugin';
+import type { IWebpackPluginOptions } from './Webpack4Plugin';
 import type { IWebpackConfiguration, IWebpackConfigurationFnEnvironment } from './shared';
 
 type IWebpackConfigJsExport =
@@ -18,7 +18,7 @@ type IWebpackConfigJsExport =
   | ((env: IWebpackConfigurationFnEnvironment) => Promise<TWebpack.Configuration | TWebpack.Configuration[]>);
 type IWebpackConfigJs = IWebpackConfigJsExport | { default: IWebpackConfigJsExport };
 
-interface ILoadWebpackConfigurationOptions extends IWebpack4PluginOptions {
+interface ILoadWebpackConfigurationOptions extends IWebpackPluginOptions {
   taskSession: IHeftTaskSession;
   heftConfiguration: HeftConfiguration;
   loadWebpackAsyncFn: () => Promise<typeof TWebpack>;

--- a/heft-plugins/heft-webpack4-plugin/src/shared.ts
+++ b/heft-plugins/heft-webpack4-plugin/src/shared.ts
@@ -7,6 +7,11 @@ declare module 'webpack' {
   export type MultiStats = TWebpack.compilation.MultiStats;
   export type StatsOptions = unknown;
   export type StatsCompilation = TWebpack.compilation.Compilation;
+
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  export interface Compiler {
+    watching?: unknown;
+  }
 }
 import type { Configuration as WebpackDevServerConfiguration } from 'webpack-dev-server';
 import type { AsyncParallelHook, AsyncSeriesBailHook, AsyncSeriesHook } from 'tapable';

--- a/heft-plugins/heft-webpack4-plugin/src/shared.ts
+++ b/heft-plugins/heft-webpack4-plugin/src/shared.ts
@@ -7,11 +7,6 @@ declare module 'webpack' {
   export type MultiStats = TWebpack.compilation.MultiStats;
   export type StatsOptions = unknown;
   export type StatsCompilation = TWebpack.compilation.Compilation;
-
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  export interface Compiler {
-    watching?: unknown;
-  }
 }
 import type { Configuration as WebpackDevServerConfiguration } from 'webpack-dev-server';
 import type { AsyncParallelHook, AsyncSeriesBailHook, AsyncSeriesHook } from 'tapable';

--- a/heft-plugins/heft-webpack5-plugin/heft-plugin.json
+++ b/heft-plugins/heft-webpack5-plugin/heft-plugin.json
@@ -5,7 +5,16 @@
     {
       "pluginName": "Webpack5Plugin",
       "entryPoint": "./lib/Webpack5Plugin",
-      "optionsSchema": "./lib/schemas/heft-webpack5-plugin.schema.json"
+      "optionsSchema": "./lib/schemas/heft-webpack5-plugin.schema.json",
+
+      "parameterScope": "webpack5",
+      "parameters": [
+        {
+          "longName": "--serve",
+          "parameterKind": "flag",
+          "description": "Start a local web server for testing purposes using webpack-dev-server.  This parameter is only available when running in watch mode."
+        }
+      ]
     }
   ]
 }

--- a/heft-plugins/heft-webpack5-plugin/package.json
+++ b/heft-plugins/heft-webpack5-plugin/package.json
@@ -22,6 +22,7 @@
     "webpack": "~5.68.0"
   },
   "dependencies": {
+    "@rushstack/debug-certificate-manager": "workspace:*",
     "@rushstack/node-core-library": "workspace:*",
     "@types/tapable": "1.0.6",
     "tapable": "1.1.3",

--- a/heft-plugins/heft-webpack5-plugin/src/Webpack5Plugin.ts
+++ b/heft-plugins/heft-webpack5-plugin/src/Webpack5Plugin.ts
@@ -288,7 +288,7 @@ export default class Webpack5Plugin implements IHeftTaskPlugin<IWebpackPluginOpt
             if (addressInfo) {
               const address: string =
                 typeof addressInfo === 'string' ? addressInfo : `${addressInfo.address}:${addressInfo.port}`;
-              taskSession.logger.terminal.writeLine(`Started Webpack Dev Server at ${address}`);
+              taskSession.logger.terminal.writeLine(`Started Webpack Dev Server at https://${address}`);
             }
           }
         };

--- a/heft-plugins/heft-webpack5-plugin/src/Webpack5Plugin.ts
+++ b/heft-plugins/heft-webpack5-plugin/src/Webpack5Plugin.ts
@@ -1,17 +1,20 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+import type { AddressInfo } from 'net';
 import type * as TWebpack from 'webpack';
 import type TWebpackDevServer from 'webpack-dev-server';
 import { AsyncParallelHook, AsyncSeriesBailHook, AsyncSeriesHook } from 'tapable';
-import { FileError, LegacyAdapters } from '@rushstack/node-core-library';
+import { CertificateManager, type ICertificate } from '@rushstack/debug-certificate-manager';
+import { FileError, InternalError, LegacyAdapters } from '@rushstack/node-core-library';
 import type {
   HeftConfiguration,
   IHeftTaskSession,
   IHeftTaskCleanHookOptions,
   IHeftTaskPlugin,
   IHeftTaskRunHookOptions,
-  IScopedLogger
+  IScopedLogger,
+  IHeftTaskRunIncrementalHookOptions
 } from '@rushstack/heft';
 
 import type {
@@ -21,7 +24,10 @@ import type {
 } from './shared';
 import { WebpackConfigurationLoader } from './WebpackConfigurationLoader';
 
-export interface IWebpack5PluginOptions {
+type ExtendedCompiler = TWebpack.Compiler & { watching: TWebpack.Watching };
+type ExtendedMultiCompiler = TWebpack.MultiCompiler & { compilers: ExtendedCompiler[] };
+
+export interface IWebpackPluginOptions {
   devConfigurationPath: string | undefined;
   configurationPath: string | undefined;
 }
@@ -30,16 +36,22 @@ export interface IWebpack5PluginOptions {
  * @public
  */
 export const PLUGIN_NAME: 'Webpack5Plugin' = 'Webpack5Plugin';
+const WEBPACK_PACKAGE_NAME: 'webpack' = 'webpack';
 const WEBPACK_DEV_SERVER_PACKAGE_NAME: 'webpack-dev-server' = 'webpack-dev-server';
 const WEBPACK_DEV_SERVER_ENV_VAR_NAME: 'WEBPACK_DEV_SERVER' = 'WEBPACK_DEV_SERVER';
+const WEBPACK_DEV_MIDDLEWARE_PACKAGE_NAME: 'webpack-dev-middleware' = 'webpack-dev-middleware';
 const UNINITIALIZED: 'UNINITIALIZED' = 'UNINITIALIZED';
 
 /**
  * @internal
  */
-export default class Webpack5Plugin implements IHeftTaskPlugin<IWebpack5PluginOptions> {
+export default class Webpack5Plugin implements IHeftTaskPlugin<IWebpackPluginOptions> {
   private _webpack: typeof TWebpack | undefined;
+  private _webpackCompiler: ExtendedCompiler | ExtendedMultiCompiler | undefined;
   private _webpackConfiguration: IWebpackConfiguration | undefined | typeof UNINITIALIZED = UNINITIALIZED;
+  private _webpackWatchers: TWebpack.Watching[] | undefined;
+  private _webpackCompilationDonePromise: Promise<void> | undefined;
+  private _webpackCompilationDonePromiseResolveFn: (() => void) | undefined;
 
   public readonly accessor: IWebpackPluginAccessor = {
     hooks: {
@@ -53,35 +65,12 @@ export default class Webpack5Plugin implements IHeftTaskPlugin<IWebpack5PluginOp
   public apply(
     taskSession: IHeftTaskSession,
     heftConfiguration: HeftConfiguration,
-    options: IWebpack5PluginOptions
+    options: IWebpackPluginOptions
   ): void {
-    // These get set in the run hook and used in the onConfigureWebpackHook
-    let production: boolean;
-    let serveMode: boolean;
-    let watchMode: boolean;
-
-    // TODO: Move this into _getWebpackConfigurationAsync once default parameters are moved
-    const getDefaultWebpackConfigurationFn: () => Promise<IWebpackConfiguration | undefined> = async () => {
-      taskSession.logger.terminal.writeVerboseLine('Loading default Webpack configuration');
-      const configurationLoader: WebpackConfigurationLoader = new WebpackConfigurationLoader(
-        taskSession.logger,
-        production,
-        serveMode
-      );
-      return await configurationLoader.tryLoadWebpackConfigurationAsync({
-        ...options,
-        taskSession,
-        heftConfiguration,
-        loadWebpackAsyncFn: this._loadWebpackAsync.bind(this)
-      });
-    };
-
     taskSession.hooks.clean.tapPromise(PLUGIN_NAME, async (cleanOptions: IHeftTaskCleanHookOptions) => {
-      production = taskSession.parameters.production;
-
       // Obtain the finalized webpack configuration
       const webpackConfiguration: IWebpackConfiguration | undefined =
-        await this._getWebpackConfigurationAsync(getDefaultWebpackConfigurationFn);
+        await this._getWebpackConfigurationAsync(taskSession, heftConfiguration, options);
       if (webpackConfiguration) {
         const webpackConfigurationArray: IWebpackConfigurationWithDevServer[] = Array.isArray(
           webpackConfiguration
@@ -101,37 +90,53 @@ export default class Webpack5Plugin implements IHeftTaskPlugin<IWebpack5PluginOp
     });
 
     taskSession.hooks.run.tapPromise(PLUGIN_NAME, async (runOptions: IHeftTaskRunHookOptions) => {
-      production = taskSession.parameters.production;
-      // TODO: Support watch mode
-      watchMode = false;
-      // TODO: Support serve mode
-      serveMode = false;
-
-      // Run webpack with the finalized webpack configuration
-      const webpackConfiguration: IWebpackConfiguration | undefined =
-        await this._getWebpackConfigurationAsync(getDefaultWebpackConfigurationFn);
-      await this._runWebpackAsync(taskSession, heftConfiguration, webpackConfiguration, serveMode, watchMode);
+      await this._runWebpackAsync(taskSession, heftConfiguration, options);
     });
-  }
 
-  private async _loadWebpackAsync(): Promise<typeof TWebpack> {
-    if (!this._webpack) {
-      this._webpack = await import('webpack');
-    }
-    return this._webpack;
+    taskSession.hooks.runIncremental.tapPromise(
+      PLUGIN_NAME,
+      async (runOptions: IHeftTaskRunIncrementalHookOptions) => {
+        await this._runWebpackWatchAsync(taskSession, heftConfiguration, options);
+      }
+    );
   }
 
   private async _getWebpackConfigurationAsync(
-    getDefaultWebpackConfigurationFn: () => Promise<IWebpackConfiguration | undefined>
+    taskSession: IHeftTaskSession,
+    heftConfiguration: HeftConfiguration,
+    options: IWebpackPluginOptions
   ): Promise<IWebpackConfiguration | undefined> {
     if (this._webpackConfiguration === UNINITIALIZED) {
       // Obtain the webpack configuration by calling into the hook. If undefined
       // is returned, load the default Webpack configuration.
-      const webpackConfiguration: IWebpackConfiguration | false | undefined =
-        (await this.accessor.hooks.onLoadConfiguration.promise()) ??
-        (await getDefaultWebpackConfigurationFn());
+      taskSession.logger.terminal.writeVerboseLine(
+        'Attempting to load Webpack configuration via external plugins'
+      );
+      let webpackConfiguration: IWebpackConfiguration | false | undefined =
+        await this.accessor.hooks.onLoadConfiguration.promise();
+      if (webpackConfiguration === undefined) {
+        taskSession.logger.terminal.writeVerboseLine('Attempt to load the default Webpack configuration');
+        const configurationLoader: WebpackConfigurationLoader = new WebpackConfigurationLoader(
+          taskSession.logger,
+          taskSession.parameters.production,
+          taskSession.parameters.watch && taskSession.parameters.serve
+        );
+        webpackConfiguration = await configurationLoader.tryLoadWebpackConfigurationAsync({
+          ...options,
+          taskSession,
+          heftConfiguration,
+          loadWebpackAsyncFn: this._loadWebpackAsync.bind(this)
+        });
+      }
 
-      if (!webpackConfiguration) {
+      if (webpackConfiguration === false) {
+        taskSession.logger.terminal.writeLine('Webpack disabled by external plugin');
+        this._webpackConfiguration = undefined;
+      } else if (
+        webpackConfiguration === undefined ||
+        (Array.isArray(webpackConfiguration) && webpackConfiguration.length === 0)
+      ) {
+        taskSession.logger.terminal.writeLine('No Webpack configuration found');
         this._webpackConfiguration = undefined;
       } else {
         if (this.accessor.hooks.onConfigure.isUsed()) {
@@ -148,131 +153,239 @@ export default class Webpack5Plugin implements IHeftTaskPlugin<IWebpack5PluginOp
     return this._webpackConfiguration;
   }
 
+  private async _loadWebpackAsync(): Promise<typeof TWebpack> {
+    if (!this._webpack) {
+      // Allow this to fail if webpack is not installed
+      this._webpack = await import(WEBPACK_PACKAGE_NAME);
+    }
+    return this._webpack!;
+  }
+
+  private async _getWebpackCompilerAsync(
+    taskSession: IHeftTaskSession,
+    webpackConfiguration: IWebpackConfiguration
+  ): Promise<ExtendedCompiler | ExtendedMultiCompiler> {
+    if (!this._webpackCompiler) {
+      const webpack: typeof TWebpack = await this._loadWebpackAsync();
+      taskSession.logger.terminal.writeLine(`Using Webpack version ${webpack.version}`);
+      this._webpackCompiler = Array.isArray(webpackConfiguration)
+        ? webpack.default(webpackConfiguration) /* (webpack.Compilation[]) => MultiCompiler */
+        : webpack.default(webpackConfiguration); /* (webpack.Compilation) => Compiler */
+    }
+    return this._webpackCompiler;
+  }
+
   private async _runWebpackAsync(
     taskSession: IHeftTaskSession,
     heftConfiguration: HeftConfiguration,
-    webpackConfiguration: IWebpackConfiguration | undefined,
-    serveMode: boolean,
-    watchMode: boolean
+    options: IWebpackPluginOptions
   ): Promise<void> {
-    const logger: IScopedLogger = taskSession.logger;
+    this._validateEnvironmentVariable(taskSession);
+    if (taskSession.parameters.watch || taskSession.parameters.serve) {
+      // Should never happen, but just in case
+      throw new InternalError('Cannot run Webpack in compilation mode when watch mode is enabled');
+    }
 
+    // Load the config and compiler, and return if there is no config found
+    const webpackConfiguration: IWebpackConfiguration | undefined = await this._getWebpackConfigurationAsync(
+      taskSession,
+      heftConfiguration,
+      options
+    );
     if (!webpackConfiguration) {
-      logger.terminal.writeLine('Webpack configuration not provided, running Webpack skipped');
       return;
     }
+    const compiler: ExtendedCompiler | ExtendedMultiCompiler = await this._getWebpackCompilerAsync(
+      taskSession,
+      webpackConfiguration
+    );
+    taskSession.logger.terminal.writeLine('Running Webpack compilation');
 
-    const webpack: typeof TWebpack = await this._loadWebpackAsync();
-    logger.terminal.writeLine(`Using Webpack version ${webpack.version}`);
-
-    let compiler: TWebpack.Compiler | TWebpack.MultiCompiler;
-    if (Array.isArray(webpackConfiguration)) {
-      if (webpackConfiguration.length === 0) {
-        logger.terminal.writeLine('The webpack configuration is an empty array - nothing to do.');
-        return;
-      } else {
-        compiler = webpack.default(webpackConfiguration); /* (webpack.Compilation[]) => MultiCompiler */
-      }
-    } else {
-      compiler = webpack.default(webpackConfiguration); /* (webpack.Compilation) => Compiler */
+    // Run the webpack compiler
+    let stats: TWebpack.Stats | TWebpack.MultiStats | undefined;
+    try {
+      stats = await LegacyAdapters.convertCallbackToPromise(
+        (compiler as ExtendedCompiler).run.bind(compiler)
+      );
+      await LegacyAdapters.convertCallbackToPromise(compiler.close.bind(compiler));
+    } catch (e) {
+      taskSession.logger.emitError(e as Error);
     }
 
-    if (serveMode) {
-      const defaultDevServerOptions: TWebpackDevServer.Configuration = {
-        host: 'localhost',
-        devMiddleware: {
-          publicPath: '/',
-          stats: {
-            cached: false,
-            cachedAssets: false,
-            colors: heftConfiguration.terminalProvider.supportsColor
+    // Emit the errors from the stats object, if present
+    if (stats) {
+      this._emitErrors(taskSession.logger, stats, heftConfiguration.buildFolderPath);
+      if (this.accessor.hooks.onEmitStats.isUsed()) {
+        await this.accessor.hooks.onEmitStats.promise(stats);
+      }
+    }
+  }
+
+  private async _runWebpackWatchAsync(
+    taskSession: IHeftTaskSession,
+    heftConfiguration: HeftConfiguration,
+    options: IWebpackPluginOptions
+  ): Promise<void> {
+    // Save a handle to the original promise, since the this-scoped promise will be replaced whenever
+    // the compilation completes.
+    let webpackCompilationDonePromise: Promise<void> | undefined = this._webpackCompilationDonePromise;
+
+    if (!this._webpackWatchers) {
+      this._validateEnvironmentVariable(taskSession);
+      if (!taskSession.parameters.watch) {
+        // Should never happen, but just in case
+        throw new InternalError('Cannot run Webpack in watch mode when compilation mode is enabled');
+      }
+
+      // Load the config and compiler, and return if there is no config found
+      const webpackConfiguration: IWebpackConfiguration | undefined =
+        await this._getWebpackConfigurationAsync(taskSession, heftConfiguration, options);
+      if (!webpackConfiguration) {
+        return;
+      }
+
+      // Get the compiler which will be used for both serve and watch mode
+      const compiler: ExtendedCompiler | ExtendedMultiCompiler = await this._getWebpackCompilerAsync(
+        taskSession,
+        webpackConfiguration
+      );
+
+      // Set up the hook to detect when the watcher completes the watcher compilation. We will also log out
+      // errors from the compilation if present from the output stats object.
+      this._webpackCompilationDonePromise = new Promise((resolve: () => void) => {
+        this._webpackCompilationDonePromiseResolveFn = resolve;
+      });
+      webpackCompilationDonePromise = this._webpackCompilationDonePromise;
+      compiler.hooks.done.tap(PLUGIN_NAME, (stats?: TWebpack.Stats | TWebpack.MultiStats) => {
+        this._webpackCompilationDonePromiseResolveFn!();
+        this._webpackCompilationDonePromise = new Promise((resolve: () => void) => {
+          this._webpackCompilationDonePromiseResolveFn = resolve;
+        });
+        if (stats) {
+          this._emitErrors(taskSession.logger, stats, heftConfiguration.buildFolderPath);
+        }
+      });
+
+      // Determine how we will run the compiler. When serving, we will run the compiler
+      // via the webpack-dev-server. Otherwise, we will run the compiler directly.
+      if (taskSession.parameters.serve) {
+        const defaultDevServerOptions: TWebpackDevServer.Configuration = {
+          host: 'localhost',
+          devMiddleware: {
+            publicPath: '/',
+            stats: {
+              cached: false,
+              cachedAssets: false,
+              colors: heftConfiguration.terminalProvider.supportsColor
+            }
+          },
+          client: {
+            logging: 'info'
+          },
+          port: 8080,
+          onListening: (server: TWebpackDevServer) => {
+            const addressInfo: AddressInfo | string | undefined = server.server?.address() as AddressInfo;
+            if (addressInfo) {
+              const address: string =
+                typeof addressInfo === 'string' ? addressInfo : `${addressInfo.address}:${addressInfo.port}`;
+              taskSession.logger.terminal.writeLine(`Started Webpack Dev Server at ${address}`);
+            }
           }
-        },
-        client: {
-          logging: 'info'
-        },
-        port: 8080
-      };
+        };
 
-      let options: TWebpackDevServer.Configuration;
-      if (Array.isArray(webpackConfiguration)) {
-        const devServerOptions: TWebpackDevServer.Configuration[] = webpackConfiguration
-          .map((configuration) => configuration.devServer)
-          .filter((devServer): devServer is TWebpackDevServer.Configuration => !!devServer);
-        if (devServerOptions.length > 1) {
-          logger.emitWarning(
-            new Error(`Detected multiple webpack devServer configurations, using the first one.`)
-          );
-        }
-
-        if (devServerOptions.length > 0) {
-          options = { ...defaultDevServerOptions, ...devServerOptions[0] };
+        // Obtain the devServerOptions from the webpack configuration, and combine with the default options
+        let devServerOptions: TWebpackDevServer.Configuration;
+        if (Array.isArray(webpackConfiguration)) {
+          const filteredDevServerOptions: TWebpackDevServer.Configuration[] = webpackConfiguration
+            .map((configuration) => configuration.devServer)
+            .filter((devServer): devServer is TWebpackDevServer.Configuration => !!devServer);
+          if (filteredDevServerOptions.length > 1) {
+            taskSession.logger.emitWarning(
+              new Error(`Detected multiple webpack devServer configurations, using the first one.`)
+            );
+          }
+          devServerOptions = { ...defaultDevServerOptions, ...filteredDevServerOptions[0] };
         } else {
-          options = defaultDevServerOptions;
+          devServerOptions = { ...defaultDevServerOptions, ...webpackConfiguration.devServer };
         }
-      } else {
-        options = { ...defaultDevServerOptions, ...webpackConfiguration.devServer };
-      }
 
-      // Register a plugin to callback after webpack is done with the first compilation
-      // so we can move on to post-build
-      let firstCompilationDoneCallback: (() => void) | undefined;
-      compiler.hooks.done.tap(PLUGIN_NAME, () => {
-        if (firstCompilationDoneCallback) {
-          firstCompilationDoneCallback();
-          firstCompilationDoneCallback = undefined;
-        }
-      });
-
-      // The webpack-dev-server package has a design flaw, where merely loading its package will set the
-      // WEBPACK_DEV_SERVER environment variable -- even if no APIs are accessed. This environment variable
-      // causes incorrect behavior if Heft is not running in serve mode. Thus, we need to be careful to call
-      // require() only if Heft is in serve mode.
-      const WebpackDevServer: typeof TWebpackDevServer = await import(WEBPACK_DEV_SERVER_PACKAGE_NAME);
-      const webpackDevServer: TWebpackDevServer = new WebpackDevServer(options, compiler);
-
-      await new Promise<void>((resolve: () => void, reject: (error: Error) => void) => {
-        firstCompilationDoneCallback = resolve;
-        webpackDevServer.start().catch(reject);
-      });
-    } else {
-      if (process.env[WEBPACK_DEV_SERVER_ENV_VAR_NAME]) {
-        logger.emitWarning(
-          new Error(
-            `The "${WEBPACK_DEV_SERVER_ENV_VAR_NAME}" environment variable is set, ` +
-              'which will cause problems when webpack is not running in serve mode. ' +
-              `(Did a dependency inadvertently load the "${WEBPACK_DEV_SERVER_PACKAGE_NAME}" package?)`
-          )
+        // Add the certificate and key to the devServerOptions
+        const certificateManager: CertificateManager = new CertificateManager();
+        const certificate: ICertificate = await certificateManager.ensureCertificateAsync(
+          true,
+          taskSession.logger.terminal
         );
-      }
+        devServerOptions = {
+          ...devServerOptions,
+          server: {
+            type: 'https',
+            options: {
+              key: certificate.pemKey,
+              cert: certificate.pemCertificate
+            }
+          }
+        };
 
-      let stats: TWebpack.Stats | TWebpack.MultiStats | undefined;
-      if (watchMode) {
-        try {
-          stats = await LegacyAdapters.convertCallbackToPromise(
-            (compiler as TWebpack.Compiler).watch.bind(compiler),
-            {}
-          );
-        } catch (e) {
-          logger.emitError(e as Error);
-        }
+        // Since the webpack-dev-server does not return infrastructure errors via a callback like
+        // compiler.watch(...), we will need to intercept them and log them ourselves.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        compiler.hooks.infrastructureLog.tap(PLUGIN_NAME, (name: string, type: string, args: any[]) => {
+          if (name === WEBPACK_DEV_MIDDLEWARE_PACKAGE_NAME && type === 'error') {
+            const error: Error | undefined = args[0];
+            if (error) {
+              taskSession.logger.emitError(error);
+            }
+          }
+          return true;
+        });
+
+        // The webpack-dev-server package has a design flaw, where merely loading its package will set the
+        // WEBPACK_DEV_SERVER environment variable -- even if no APIs are accessed. This environment variable
+        // causes incorrect behavior if Heft is not running in serve mode. Thus, we need to be careful to call
+        // require() only if Heft is in serve mode.
+        taskSession.logger.terminal.writeLine('Starting webpack-dev-server');
+        const WebpackDevServer: typeof TWebpackDevServer = (await import(WEBPACK_DEV_SERVER_PACKAGE_NAME))
+          .default;
+        const webpackDevServer: TWebpackDevServer = new WebpackDevServer(devServerOptions, compiler);
+        await webpackDevServer.start();
       } else {
-        try {
-          stats = await LegacyAdapters.convertCallbackToPromise(
-            (compiler as TWebpack.Compiler).run.bind(compiler)
-          );
-          await LegacyAdapters.convertCallbackToPromise(compiler.close.bind(compiler));
-        } catch (e) {
-          logger.emitError(e as Error);
-        }
+        // Create the watcher. Compilation will start immediately after invoking watch().
+        taskSession.logger.terminal.writeLine('Starting Webpack watcher');
+        compiler.watch({}, (error?: Error | null) => {
+          if (error) {
+            taskSession.logger.emitError(error);
+          }
+        });
       }
 
-      if (stats) {
-        this._emitErrors(logger, stats, heftConfiguration.buildFolderPath);
-        if (this.accessor.hooks.onEmitStats.isUsed()) {
-          await this.accessor.hooks.onEmitStats.promise(stats);
-        }
-      }
+      // Store the watchers to be used for suspend/resume
+      this._webpackWatchers = (compiler as ExtendedMultiCompiler).compilers?.map(
+        (compiler: ExtendedCompiler) => compiler.watching
+      ) ?? [(compiler as ExtendedCompiler).watching];
+    }
+
+    // Resume the compilation, wait for the compilation to complete, then suspend the watchers until the
+    // next iteration. Even if there are no changes, the promise should resolve since resuming from a
+    // suspended state invalidates the state of the watcher.
+    taskSession.logger.terminal.writeLine('Running incremental Webpack compilation');
+    for (const watcher of this._webpackWatchers) {
+      watcher.resume();
+    }
+    await webpackCompilationDonePromise;
+    for (const watcher of this._webpackWatchers) {
+      watcher.suspend();
+    }
+  }
+
+  private _validateEnvironmentVariable(taskSession: IHeftTaskSession): void {
+    if (!taskSession.parameters.serve && process.env[WEBPACK_DEV_SERVER_ENV_VAR_NAME]) {
+      taskSession.logger.emitWarning(
+        new Error(
+          `The "${WEBPACK_DEV_SERVER_ENV_VAR_NAME}" environment variable is set, ` +
+            'which will cause problems when webpack is not running in serve mode. ' +
+            `(Did a dependency inadvertently load the "${WEBPACK_DEV_SERVER_PACKAGE_NAME}" package?)`
+        )
+      );
     }
   }
 

--- a/heft-plugins/heft-webpack5-plugin/src/Webpack5Plugin.ts
+++ b/heft-plugins/heft-webpack5-plugin/src/Webpack5Plugin.ts
@@ -372,9 +372,9 @@ export default class Webpack5Plugin implements IHeftTaskPlugin<IWebpackPluginOpt
       }
 
       // Store the watchers to be used for suspend/resume
-      this._webpackWatchers = (compiler as ExtendedMultiCompiler).compilers?.map(
-        (compiler: ExtendedCompiler) => compiler.watching
-      ) ?? [(compiler as ExtendedCompiler).watching];
+      this._webpackWatchers = (
+        (compiler as ExtendedMultiCompiler).compilers ?? [compiler as ExtendedCompiler]
+      ).map((compiler: ExtendedCompiler) => compiler.watching);
     }
 
     // Resume the compilation, wait for the compilation to complete, then suspend the watchers until the

--- a/heft-plugins/heft-webpack5-plugin/src/Webpack5Plugin.ts
+++ b/heft-plugins/heft-webpack5-plugin/src/Webpack5Plugin.ts
@@ -320,22 +320,24 @@ export default class Webpack5Plugin implements IHeftTaskPlugin<IWebpackPluginOpt
           devServerOptions = { ...defaultDevServerOptions, ...webpackConfiguration.devServer };
         }
 
-        // Add the certificate and key to the devServerOptions
-        const certificateManager: CertificateManager = new CertificateManager();
-        const certificate: ICertificate = await certificateManager.ensureCertificateAsync(
-          true,
-          taskSession.logger.terminal
-        );
-        devServerOptions = {
-          ...devServerOptions,
-          server: {
-            type: 'https',
-            options: {
-              key: certificate.pemKey,
-              cert: certificate.pemCertificate
+        // Add the certificate and key to the devServerOptions if these fields don't already have values
+        if (!devServerOptions.server) {
+          const certificateManager: CertificateManager = new CertificateManager();
+          const certificate: ICertificate = await certificateManager.ensureCertificateAsync(
+            true,
+            taskSession.logger.terminal
+          );
+          devServerOptions = {
+            ...devServerOptions,
+            server: {
+              type: 'https',
+              options: {
+                key: certificate.pemKey,
+                cert: certificate.pemCertificate
+              }
             }
-          }
-        };
+          };
+        }
 
         // Since the webpack-dev-server does not return infrastructure errors via a callback like
         // compiler.watch(...), we will need to intercept them and log them ourselves.

--- a/heft-plugins/heft-webpack5-plugin/src/WebpackConfigurationLoader.ts
+++ b/heft-plugins/heft-webpack5-plugin/src/WebpackConfigurationLoader.ts
@@ -6,7 +6,7 @@ import type * as TWebpack from 'webpack';
 import { FileSystem } from '@rushstack/node-core-library';
 import type { IScopedLogger, IHeftTaskSession, HeftConfiguration } from '@rushstack/heft';
 
-import type { IWebpack5PluginOptions } from './Webpack5Plugin';
+import type { IWebpackPluginOptions } from './Webpack5Plugin';
 import type { IWebpackConfiguration, IWebpackConfigurationFnEnvironment } from './shared';
 
 type IWebpackConfigJsExport =
@@ -18,7 +18,7 @@ type IWebpackConfigJsExport =
   | ((env: IWebpackConfigurationFnEnvironment) => Promise<TWebpack.Configuration | TWebpack.Configuration[]>);
 type IWebpackConfigJs = IWebpackConfigJsExport | { default: IWebpackConfigJsExport };
 
-interface ILoadWebpackConfigurationOptions extends IWebpack5PluginOptions {
+interface ILoadWebpackConfigurationOptions extends IWebpackPluginOptions {
   taskSession: IHeftTaskSession;
   heftConfiguration: HeftConfiguration;
   loadWebpackAsyncFn: () => Promise<typeof TWebpack>;

--- a/libraries/module-minifier/src/WorkerPoolMinifier.ts
+++ b/libraries/module-minifier/src/WorkerPoolMinifier.ts
@@ -167,6 +167,8 @@ export class WorkerPoolMinifier implements IModuleMinifier {
             console.log(`Module minification: ${this._deduped} Deduped, ${this._minified} Processed`);
           }
         }
+        this._deduped = 0;
+        this._minified = 0;
       }
     };
   }


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary
Update `@rushstack/heft-webpack5-plugin` and `@rushstack/heft-webpack4-plugin` to support proper incremental build flows with `-watch` commands (including `--serve`).