### PR TITLE
[heft-typescript] Support solutions in watch

### DIFF
--- a/heft-plugins/heft-typescript-plugin/src/EmitFilesPatch.ts
+++ b/heft-plugins/heft-typescript-plugin/src/EmitFilesPatch.ts
@@ -35,7 +35,7 @@ export class EmitFilesPatch {
 
   public static install(
     ts: ExtendedTypeScript,
-    tsconfig: TTypescript.ParsedCommandLine,
+    baseCompilerOptions: TTypescript.CompilerOptions,
     moduleKindsToEmit: ICachedEmitModuleKind[],
     changedFiles?: Set<TTypescript.SourceFile>
   ): void {
@@ -99,10 +99,10 @@ export class EmitFilesPatch {
         for (const moduleKindToEmit of moduleKindsToEmit) {
           const compilerOptions: TTypescript.CompilerOptions = moduleKindToEmit.isPrimary
             ? {
-                ...tsconfig.options
+                ...baseCompilerOptions
               }
             : {
-                ...tsconfig.options,
+                ...baseCompilerOptions,
                 module: moduleKindToEmit.moduleKind,
                 outDir: moduleKindToEmit.outFolderPath,
 

--- a/heft-plugins/heft-typescript-plugin/src/internalTypings/TypeScriptInternals.ts
+++ b/heft-plugins/heft-typescript-plugin/src/internalTypings/TypeScriptInternals.ts
@@ -30,6 +30,12 @@ export interface IResolveModuleNameResolutionHost {
   getCurrentDirectory(): string;
 }
 
+export interface IExtendedSolutionBuilder
+  extends TTypescript.SolutionBuilder<TTypescript.EmitAndSemanticDiagnosticsBuilderProgram> {
+  getBuildOrder(): readonly string[];
+  invalidateProject(configFilePath: string, mode: 0 | 1 | 2): void;
+}
+
 /**
  * @beta
  */


### PR DESCRIPTION
## Summary
Adds stronger support for solution projects in incremental watch mode.

## Details
Leverages the same source file cache as the non-solution mode.
Reworks the interaction between the SolutionBuilder and the EmitFilesPatch to only mutate typescript during the synchronous invocation of the emit calls.

Gaps:
- Triggering a rebuild if a file outside of the working directory is added

## How it was tested
Repeated watch-mode runs of heft-typescript-composite-test with various changes.